### PR TITLE
fix: audit quits

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -75,9 +75,9 @@ type syncStatusMsg struct {
 }
 
 type processDoneMsg struct {
-	name     string
-	err      error
-	exitBast bool
+	name       string
+	err        error
+	sshSession bool
 }
 
 type clearStatusMsg uint64
@@ -225,17 +225,14 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case processDoneMsg:
-		if msg.err == nil && msg.exitBast {
-			return m, tea.Quit
-		}
 		m.loading = true
+		if msg.sshSession {
+			m.statusID++
+			m.status, m.statusError = "", false
+			return m, m.loadCmd()
+		}
 		if msg.err != nil {
 			m.statusID++
-			if msg.exitBast {
-				// SSH already showed its output under a continue prompt; skip the overlay.
-				m.status, m.statusError = "", false
-				return m, m.loadCmd()
-			}
 			m.status, m.statusError = msg.name+": "+openssh.FormatError(msg.err), true
 			return m, m.loadCmd()
 		}
@@ -263,11 +260,14 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
 		if m.statusError && m.status != "" {
 			switch msg.String() {
-			case "ctrl+c", "q":
+			case "q":
 				return m, tea.Quit
-			case "enter", "esc":
+			case "enter", "esc", "backspace", "ctrl+h":
 				m.statusID++
 				m.status, m.statusError = "", false
 			}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -204,6 +204,27 @@ func TestEscapeReturnsToParentThenQuitsAtRoot(t *testing.T) {
 	}
 }
 
+func TestBackspaceQuitsAtRootAndReturnsFromSyncProvider(t *testing.T) {
+	for _, key := range []tea.KeyPressMsg{
+		tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}),
+		tea.KeyPressMsg(tea.Key{Code: 'h', Mod: tea.ModCtrl}),
+	} {
+		for _, section := range []section{hostsSection, keysSection, syncSection} {
+			m := testApp(t)
+			m.section = section
+			_, cmd := m.Update(key)
+			requireQuit(t, cmd)
+		}
+
+		m := testApp(t)
+		m.section, m.syncProvider = syncSection, "gcp"
+		_, cmd := m.Update(key)
+		if cmd != nil || m.syncProvider != "" {
+			t.Fatalf("backspace should return from Sync provider: provider=%q cmd=%v", m.syncProvider, cmd)
+		}
+	}
+}
+
 func TestNewlyCreatedItemsAreSelectedAfterReload(t *testing.T) {
 	m := testApp(t)
 	m.search = "old filter"
@@ -523,12 +544,19 @@ func TestFooterShowsControlsForTheActiveFormState(t *testing.T) {
 	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Ctrl+Enter save") || !strings.Contains(footer, "Tab move") || strings.Contains(footer, "connect") {
 		t.Fatalf("edit footer = %q", footer)
 	}
+	enterHostFormSection(t, m, formSectionMetadata)
+	if footer := m.renderFooter(m.styles()); strings.Contains(footer, "q quit") {
+		t.Fatalf("plain-text host field advertises q as quit: %q", footer)
+	}
 
 	m.hosts[0].Managed = true
 	m.openEditHostForm()
 	enterHostFormSection(t, m, formSectionAuth)
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "q quit") {
+		t.Fatalf("selectable host field does not advertise q as quit: %q", footer)
+	}
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
 	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "choose") || !strings.Contains(footer, "Enter select") || !strings.Contains(footer, "Esc back") {
 		t.Fatalf("choice footer = %q", footer)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -45,6 +45,16 @@ func ctrlC() tea.KeyPressMsg {
 	return tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl})
 }
 
+func requireQuit(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected quit command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatal("command did not return tea.Quit")
+	}
+}
+
 func enterHostFormSection(t *testing.T, m *App, section string) {
 	t.Helper()
 	for i, item := range hostHubItems(m.form) {
@@ -91,6 +101,106 @@ func TestNumberedNavigationAndSearch(t *testing.T) {
 	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 	if got := m.filteredHosts(); len(got) != 1 || got[0].Alias != "beta" {
 		t.Fatalf("filter = %+v", got)
+	}
+}
+
+func TestCtrlCQuitsFromEveryBastContext(t *testing.T) {
+	contexts := map[string]func(*App){
+		"root":   func(*App) {},
+		"help":   func(m *App) { m.help = true },
+		"about":  func(m *App) { m.credits = true },
+		"search": func(m *App) { m.search = "\x00query" },
+		"error":  func(m *App) { m.status, m.statusError = "failed", true },
+		"host form": func(m *App) {
+			m.openAddHostForm()
+		},
+		"generic form": func(m *App) {
+			m.openGenerateForm()
+		},
+	}
+	for name, setup := range contexts {
+		t.Run(name, func(t *testing.T) {
+			m := testApp(t)
+			setup(m)
+			_, cmd := m.Update(ctrlC())
+			requireQuit(t, cmd)
+		})
+	}
+}
+
+func TestQQuitsOutsideTextInput(t *testing.T) {
+	for _, context := range []string{"root", "help", "about"} {
+		t.Run(context, func(t *testing.T) {
+			m := testApp(t)
+			m.help = context == "help"
+			m.credits = context == "about"
+			_, cmd := m.Update(press("q"))
+			requireQuit(t, cmd)
+		})
+	}
+
+	m := testApp(t)
+	m.search = "\x00"
+	_, cmd := m.Update(press("q"))
+	if cmd != nil || m.search != "\x00q" {
+		t.Fatalf("q should type in search: search=%q cmd=%v", m.search, cmd)
+	}
+
+	m = testApp(t)
+	m.openGenerateForm()
+	_, cmd = m.Update(press("q"))
+	if cmd != nil {
+		if _, ok := cmd().(tea.QuitMsg); ok {
+			t.Fatal("q quit from a generic text field")
+		}
+	}
+	if m.form.input.Value() != "q" {
+		t.Fatalf("q should type in a generic form: value=%q", m.form.input.Value())
+	}
+
+	m = testApp(t)
+	m.keys = []keymodel.Key{{Name: "work", PublicPath: "/tmp/work.pub"}}
+	m.openInstallKeyForm()
+	_, cmd = m.Update(press("q"))
+	requireQuit(t, cmd)
+}
+
+func TestEscapeReturnsToParentThenQuitsAtRoot(t *testing.T) {
+	for _, section := range []section{hostsSection, keysSection, syncSection} {
+		t.Run(fmt.Sprint(section), func(t *testing.T) {
+			m := testApp(t)
+			m.section = section
+			_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+			requireQuit(t, cmd)
+		})
+	}
+
+	m := testApp(t)
+	m.section, m.syncProvider = syncSection, "gcp"
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if cmd != nil || m.syncProvider != "" {
+		t.Fatalf("Esc should return from provider: provider=%q cmd=%v", m.syncProvider, cmd)
+	}
+
+	m = testApp(t)
+	m.help = true
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if m.help {
+		t.Fatal("Esc did not close help")
+	}
+
+	m = testApp(t)
+	m.search = "\x00query"
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if m.search != "" {
+		t.Fatalf("Esc did not close search: %q", m.search)
+	}
+
+	m = testApp(t)
+	m.openGenerateForm()
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if m.form != nil {
+		t.Fatal("Esc did not close a generic form")
 	}
 }
 
@@ -508,11 +618,13 @@ func TestHostFormBackspaceNavigatesSubmenus(t *testing.T) {
 	m := testApp(t)
 	m.openAddHostForm()
 	enterHostFormSection(t, m, formSectionMetadata)
+	m.form.input.SetValue("")
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
-	if m.form.screen != "hub" {
-		t.Fatalf("backspace on first metadata field did not return to hub: screen=%q", m.form.screen)
+	if m.form.screen != formSectionMetadata {
+		t.Fatalf("backspace in an empty text field navigated away: screen=%q", m.form.screen)
 	}
 
+	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
 	m.form.hubIndex = 1
 	m.focusHostHubItem()
 	m.form.input.SetValue("prod")
@@ -522,24 +634,82 @@ func TestHostFormBackspaceNavigatesSubmenus(t *testing.T) {
 	}
 	m.form.input.SetValue("")
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
-	if m.form.hubIndex != 0 {
-		t.Fatalf("backspace on empty hostname should move to label: hubIndex=%d", m.form.hubIndex)
+	if m.form == nil || m.form.hubIndex != 1 {
+		t.Fatal("backspace in an empty hostname field should remain in the field")
 	}
 
 	m.form.hubIndex = 3
 	m.focusHostHubItem()
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
-	if m.form.hubIndex != 2 {
-		t.Fatalf("backspace on hub menu should move to previous row: hubIndex=%d", m.form.hubIndex)
+	if m.form != nil {
+		t.Fatal("backspace on a host hub menu should close the form")
 	}
 
+	m.openAddHostForm()
 	enterHostFormSection(t, m, formSectionAdvanced)
-	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Enter open section") || !strings.Contains(footer, "⌫ back") {
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Enter open section") || !strings.Contains(footer, "⌫/Esc back") {
 		t.Fatalf("advanced hub footer = %q", footer)
 	}
+	m.form.hubIndex = 3
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
 	if m.form.screen != "hub" {
-		t.Fatalf("backspace on the first advanced row did not return to the host hub: screen=%q", m.form.screen)
+		t.Fatalf("backspace on advanced hub did not return to host hub: screen=%q", m.form.screen)
+	}
+}
+
+func TestBackspaceReturnsFromNonTextSubmenus(t *testing.T) {
+	m := testApp(t)
+	m.section, m.syncProvider = syncSection, "gcp"
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.syncProvider != "" {
+		t.Fatalf("backspace did not leave Sync provider: %q", m.syncProvider)
+	}
+
+	m = testApp(t)
+	m.keys = []keymodel.Key{{Name: "work", PublicPath: "/tmp/work.pub"}}
+	m.openInstallKeyForm()
+	if m.form == nil || !m.form.selecting {
+		t.Fatal("install form did not open its server chooser")
+	}
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.form == nil || m.form.selecting {
+		t.Fatal("backspace did not return from the server chooser")
+	}
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.form != nil {
+		t.Fatal("backspace on a non-text form field did not close the form")
+	}
+
+	m = testApp(t)
+	m.credits = true
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.credits {
+		t.Fatal("backspace did not close About")
+	}
+
+	m = testApp(t)
+	m.status, m.statusError = "failed", true
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.status != "" || m.statusError {
+		t.Fatal("backspace did not dismiss the error overlay")
+	}
+
+	m = testApp(t)
+	m.openGenerateForm()
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.form == nil || m.form.input.Value() != "" {
+		t.Fatal("backspace in an empty generic text field navigated away")
+	}
+
+	m = testApp(t)
+	m.openAddHostForm()
+	enterAdvancedSubsection(t, m, formSectionAdvancedJump)
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+	if m.form == nil {
+		t.Fatal("backspace closed the host form from an advanced subsection")
+	}
+	if m.form.screen != formScreenAdvancedHub {
+		t.Fatalf("backspace did not return to the advanced hub: screen=%q", m.form.screen)
 	}
 }
 
@@ -975,35 +1145,32 @@ func TestSSHProcessPausesOnPrepareFailure(t *testing.T) {
 	}
 }
 
-func TestSuccessfulSSHSessionExitsBast(t *testing.T) {
-	m := testApp(t)
-	_, cmd := m.Update(processDoneMsg{name: "SSH session", exitBast: true})
-	if cmd == nil {
-		t.Fatal("successful SSH session did not request a quit")
-	}
-	if _, ok := cmd().(tea.QuitMsg); !ok {
-		t.Fatal("successful SSH session did not return tea.Quit")
-	}
-
-	m = testApp(t)
-	_, cmd = m.Update(processDoneMsg{name: "SSH session", err: errors.New("connection lost"), exitBast: true})
-	if cmd == nil {
-		t.Fatal("failed SSH session did not reload hosts")
-	}
-	if m.statusError || m.status != "" {
-		t.Fatalf("failed SSH session should return quietly to hosts, got status=%q error=%v", m.status, m.statusError)
-	}
-
-	m = testApp(t)
+func TestSSHSessionCompletionReturnsToBast(t *testing.T) {
 	exitCmd := exec.Command("/bin/sh", "-c", "exit 255")
 	exitErr := exitCmd.Run()
-	_, cmd = m.Update(processDoneMsg{name: "SSH session", err: exitErr, exitBast: true})
-	if cmd == nil || m.statusError || m.status != "" {
-		t.Fatalf("SSH exit 255 should return quietly, status=%q error=%v", m.status, m.statusError)
+	for name, sessionErr := range map[string]error{
+		"logout":          nil,
+		"connection lost": errors.New("connection lost"),
+		"exit 255":        exitErr,
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := testApp(t)
+			m.status, m.statusError = "Connected", true
+			_, cmd := m.Update(processDoneMsg{name: "SSH session", err: sessionErr, sshSession: true})
+			if cmd == nil {
+				t.Fatal("SSH completion did not reload hosts")
+			}
+			if _, ok := cmd().(tea.QuitMsg); ok {
+				t.Fatal("SSH completion quit Bast")
+			}
+			if !m.loading || m.statusError || m.status != "" {
+				t.Fatalf("SSH completion did not return quietly: loading=%v status=%q error=%v", m.loading, m.status, m.statusError)
+			}
+		})
 	}
 
-	m = testApp(t)
-	_, cmd = m.Update(processDoneMsg{name: "Key generation", err: errors.New("keygen failed")})
+	m := testApp(t)
+	_, cmd := m.Update(processDoneMsg{name: "Key generation", err: errors.New("keygen failed")})
 	if cmd == nil || !m.statusError || !strings.Contains(m.status, "keygen failed") {
 		t.Fatalf("non-SSH process failure should still show an error overlay, status=%q", m.status)
 	}
@@ -1309,7 +1476,7 @@ func TestCreditsScreenShowsAttributionAndBuildDetails(t *testing.T) {
 		"github.com/ellipse-software/bast",
 		"MIT License",
 		"v1.2.3",
-		"v / Esc close",
+		"v / Esc / ⌫ close",
 	} {
 		if !strings.Contains(rendered, text) {
 			t.Fatalf("credits screen does not contain %q:\n%s", text, rendered)

--- a/internal/ui/forms.go
+++ b/internal/ui/forms.go
@@ -106,7 +106,7 @@ func (m *App) updateForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	item := &f.fields[f.index]
 	if f.selecting {
 		switch key {
-		case "esc":
+		case "esc", "backspace", "ctrl+h":
 			f.selecting = false
 			m.focusFormField()
 		case "up", "down", "j", "k":
@@ -145,6 +145,10 @@ func (m *App) updateForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key == "esc" {
+		m.form = nil
+		return m, nil
+	}
+	if (key == "backspace" || key == "ctrl+h") && !m.formTextInputActive() {
 		m.form = nil
 		return m, nil
 	}

--- a/internal/ui/host_form.go
+++ b/internal/ui/host_form.go
@@ -346,18 +346,6 @@ func (m *App) hostSectionEnter() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *App) hostFormInputEmpty() bool {
-	return strings.TrimSpace(m.form.input.Value()) == ""
-}
-
-func (m *App) hostFormBackOnEmpty() (tea.Model, tea.Cmd) {
-	m.commitFormField()
-	if !m.moveHostSection(-1) {
-		m.exitHostSection()
-	}
-	return m, nil
-}
-
 func (m *App) updateHostForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	f := m.form
@@ -397,11 +385,6 @@ func (m *App) updateHostForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "enter":
 			return m.hostHubEnter()
 		case "backspace", "ctrl+h":
-			if m.hostFormInputEmpty() {
-				m.commitFormField()
-				m.moveHostHub(-1)
-				return m, nil
-			}
 			var cmd tea.Cmd
 			m.form.input, cmd = m.form.input.Update(msg)
 			return m, cmd
@@ -421,7 +404,8 @@ func (m *App) updateHostForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "down", "j", "tab":
 		m.moveHostHub(1)
 	case "backspace", "ctrl+h":
-		m.moveHostHub(-1)
+		m.form = nil
+		return m, nil
 	case "enter":
 		return m.hostHubEnter()
 	}
@@ -468,21 +452,13 @@ func (m *App) updateHostSectionForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.focusFormField()
 		return m, nil
 	}
-	if (key == "backspace" || key == "ctrl+h") && len(item.options) > 0 && item.options[item.selected].custom && m.hostFormInputEmpty() {
-		m.commitFormField()
-		f.selecting = true
-		m.focusFormField()
-		return m, nil
-	}
 	if key == "esc" {
 		m.exitHostSection()
 		return m, nil
 	}
 	if (key == "backspace" || key == "ctrl+h") && len(item.options) > 0 && !item.options[item.selected].custom {
 		m.commitFormField()
-		if !m.moveHostSection(-1) {
-			m.exitHostSection()
-		}
+		m.exitHostSection()
 		return m, nil
 	}
 	if key == "up" || key == "shift+tab" {
@@ -509,11 +485,6 @@ func (m *App) updateHostSectionForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if len(item.options) > 0 && !item.options[item.selected].custom {
 		return m, nil
-	}
-	if key == "backspace" || key == "ctrl+h" {
-		if m.hostFormInputEmpty() {
-			return m.hostFormBackOnEmpty()
-		}
 	}
 	var cmd tea.Cmd
 	m.form.input, cmd = m.form.input.Update(msg)
@@ -673,11 +644,11 @@ func (m *App) renderHostSectionForm(s styleSet) string {
 
 func hostFormHint(f *form) string {
 	if f.screen == formScreenAdvancedHub {
-		return "Enter open section • ↑/↓ or j/k move • ⌫ back • Ctrl+Enter save • q/Esc back"
+		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • Ctrl+Enter save • q quit"
 	}
 	if f.screen != "" && f.screen != "hub" {
 		if f.selecting {
-			return "↑/↓ or j/k choose • Enter select • q/Esc back"
+			return "↑/↓ or j/k choose • Enter select • ⌫/Esc back • q quit"
 		}
 		item := f.fields[f.index]
 		action := "Enter next"
@@ -685,19 +656,19 @@ func hostFormHint(f *form) string {
 			action = "Enter change"
 		}
 		if len(item.options) > 0 && item.options[item.selected].custom {
-			return action + " • Esc/⌫ choices • Ctrl+Enter save"
+			return action + " • Esc choices • ⌫ edit • Ctrl+Enter save"
 		}
-		return action + " • ↑/↓ or Tab move • q/Esc back • Ctrl+Enter save"
+		return action + " • ↑/↓ or Tab move • ⌫/Esc back • q quit • Ctrl+Enter save"
 	}
 
 	items := hostHubItems(f)
 	if f.hubIndex >= 0 && f.hubIndex < len(items) {
 		hub := items[f.hubIndex]
 		if hub.id == "label" || hub.id == "hostname" {
-			return "Enter next • ↑/↓ or Tab move • ⌫ back when empty • Ctrl+Enter save • q/Esc cancel"
+			return "Enter next • ↑/↓ or Tab move • Ctrl+Enter save • q type • Esc cancel"
 		}
 	}
-	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫ back • Ctrl+Enter save • q/Esc cancel"
+	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫/Esc cancel • Ctrl+Enter save • q quit"
 }
 
 func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, hidden []field) []field {

--- a/internal/ui/host_form.go
+++ b/internal/ui/host_form.go
@@ -642,7 +642,7 @@ func (m *App) renderHostSectionForm(s styleSet) string {
 	return b.String()
 }
 
-func hostFormHint(f *form) string {
+func hostFormHint(f *form, textInputActive bool) string {
 	if f.screen == formScreenAdvancedHub {
 		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • Ctrl+Enter save • q quit"
 	}
@@ -658,7 +658,11 @@ func hostFormHint(f *form) string {
 		if len(item.options) > 0 && item.options[item.selected].custom {
 			return action + " • Esc choices • ⌫ edit • Ctrl+Enter save"
 		}
-		return action + " • ↑/↓ or Tab move • ⌫/Esc back • q quit • Ctrl+Enter save"
+		hint := action + " • ↑/↓ or Tab move • ⌫/Esc back"
+		if !textInputActive {
+			hint += " • q quit"
+		}
+		return hint + " • Ctrl+Enter save"
 	}
 
 	items := hostHubItems(f)

--- a/internal/ui/host_form_advanced.go
+++ b/internal/ui/host_form_advanced.go
@@ -181,11 +181,7 @@ func (m *App) updateAdvancedHubForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.exitHostSection()
 		return m, nil
 	case "backspace", "ctrl+h":
-		if m.form.hubIndex == 0 {
-			m.exitHostSection()
-			return m, nil
-		}
-		m.moveAdvancedHub(-1)
+		m.exitHostSection()
 		return m, nil
 	case "up", "k", "shift+tab":
 		m.moveAdvancedHub(-1)

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -203,10 +203,15 @@ func (m *App) updateMouseWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
 
 func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
+	if strings.HasPrefix(m.search, "\x00") {
+		return m.updateSearch(key)
+	}
 	if m.credits {
 		if key == "?" {
 			m.credits, m.help = false, true
-		} else if key == "v" || key == "esc" || key == "q" {
+		} else if key == "q" {
+			return m, tea.Quit
+		} else if key == "v" || key == "esc" || key == "backspace" || key == "ctrl+h" {
 			m.credits = false
 		}
 		return m, nil
@@ -214,13 +219,12 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.help {
 		if key == "v" {
 			m.help, m.credits = false, true
-		} else if key == "?" || key == "esc" || key == "q" {
+		} else if key == "q" {
+			return m, tea.Quit
+		} else if key == "?" || key == "esc" || key == "backspace" || key == "ctrl+h" {
 			m.help = false
 		}
 		return m, nil
-	}
-	if strings.HasPrefix(m.search, "\x00") {
-		return m.updateSearch(key)
 	}
 	switch key {
 	case "ctrl+c", "q":
@@ -246,7 +250,12 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.section, m.syncProvider, m.syncCursor, m.search = syncSection, "", 0, ""
 		return m, m.syncStatusCmd()
 	case "esc":
-		if m.section == syncSection {
+		if m.section == syncSection && m.syncProvider != "" {
+			return m.updateSyncKeys(key)
+		}
+		return m, tea.Quit
+	case "backspace", "ctrl+h":
+		if m.section == syncSection && m.syncProvider != "" {
 			return m.updateSyncKeys(key)
 		}
 	case "up", "k":
@@ -462,9 +471,9 @@ func (m *App) startSSH(host sshconfig.Host, prepare func(func(string)) error) (t
 		}
 	}
 	telemetry.Track("connect", m.version)
-	m.status = "Connected to " + m.hostLabel(host) + "; exit closes Bast; 󰌑 then ~. force-closes SSH"
+	m.status = "Connected to " + m.hostLabel(host) + "; exit returns to Bast; 󰌑 then ~. force-closes SSH"
 	return m, tea.Exec(&connectionProcess{cmd: cmd, prepare: prepare}, func(err error) tea.Msg {
-		return processDoneMsg{name: "SSH session", err: err, exitBast: true}
+		return processDoneMsg{name: "SSH session", err: err, sshSession: true}
 	})
 }
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -258,6 +258,7 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.section == syncSection && m.syncProvider != "" {
 			return m.updateSyncKeys(key)
 		}
+		return m, tea.Quit
 	case "up", "k":
 		if m.section == syncSection {
 			return m.updateSyncKeys(key)

--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -307,7 +307,7 @@ func (m *App) updateSyncKeys(key string) (tea.Model, tea.Cmd) {
 		m.syncCursor = firstEnabledSyncItem(items)
 	case "end", "G":
 		m.syncCursor = lastEnabledSyncItem(items)
-	case "esc":
+	case "esc", "backspace", "ctrl+h":
 		if m.syncProvider != "" {
 			m.syncProvider = ""
 			m.syncCursor = 0

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -485,7 +485,7 @@ func (m *App) renderForm(s styleSet) string {
 
 func (m *App) formHint() string {
 	if isHostForm(m.form) {
-		return hostFormHint(m.form)
+		return hostFormHint(m.form, m.formTextInputActive())
 	}
 	f := m.form
 	action := "󰌑 next"

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -506,9 +506,12 @@ func (m *App) formHint() string {
 		}
 	}
 	if f.selecting {
-		return action + " • Esc close"
+		return action + " • Esc/⌫ close"
 	}
 	escape := "Esc cancel"
+	if !m.formTextInputActive() {
+		escape = "Esc/⌫ cancel"
+	}
 	if len(f.fields[f.index].options) > 0 && f.fields[f.index].options[f.fields[f.index].selected].custom {
 		escape = "Esc choices"
 	}
@@ -552,8 +555,8 @@ func contrastingTextColor(background string) (string, bool) {
 }
 
 func (m *App) renderHelp(s styleSet) string {
-	lines := []string{"Navigation", "  ↑/↓ or j/k  move       /  search       r  reload", "  1  hosts       2  keys   3  sync   ?  help         v  about       q  quit", "", "Hosts", "  󰌑 connect      a add     e edit         d delete", "  ␣ collapse/expand                        s sort", "  f favorite      h hide/show selected     . toggle hidden hosts", "  K remove known-host entry", "", "Keys", "  a generate      i import  e edit comment d delete", "  u add to server x export  p change passphrase       c copy public key", "", "Sync", "  󰌑 open provider / run action   Esc back   r refresh", "", "During SSH", "  exit closes Bast; press 󰌑 then ~. to force-close a stuck session"}
-	return "\n  " + s.active.Render("Keyboard help") + "\n\n" + strings.Join(lines, "\n") + "\n\n  " + s.muted.Render("Press ? or Esc to close")
+	lines := []string{"Navigation", "  ↑/↓ or j/k  move       /  search       r  reload", "  1  hosts       2  keys   3  sync   ?  help         v  about       q  quit", "", "Hosts", "  󰌑 connect      a add     e edit         d delete", "  ␣ collapse/expand                        s sort", "  f favorite      h hide/show selected     . toggle hidden hosts", "  K remove known-host entry", "", "Keys", "  a generate      i import  e edit comment d delete", "  u add to server x export  p change passphrase       c copy public key", "", "Sync", "  󰌑 open provider / run action   Esc back   r refresh", "", "During SSH", "  exit returns to Bast; press 󰌑 then ~. to force-close a stuck session"}
+	return "\n  " + s.active.Render("Keyboard help") + "\n\n" + strings.Join(lines, "\n") + "\n\n  " + s.muted.Render("Press ?, Esc, or ⌫ to close")
 }
 
 func (m *App) renderCredits(s styleSet) string {
@@ -589,11 +592,11 @@ func (m *App) renderCredits(s styleSet) string {
 
 func (m *App) renderFooter(s styleSet) string {
 	if m.statusError && m.status != "" {
-		hint := "Enter / Esc return"
+		hint := "Enter / Esc / ⌫ return"
 		return strings.Repeat(" ", max(1, m.terminalWidth()-lipgloss.Width(hint))) + s.muted.Render(hint)
 	}
 	if m.credits {
-		hint := "v / Esc close"
+		hint := "v / Esc / ⌫ close"
 		return strings.Repeat(" ", max(1, m.terminalWidth()-lipgloss.Width(hint))) + s.muted.Render(hint)
 	}
 	query := m.searchText()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH sessions now return to the main screen and refresh host information after completion.
  * Ctrl+C consistently exits the application from all screens.
  * Improved back-navigation and form cancellation using Backspace and Ctrl+H.
  * Updated quit behavior across search, help, credits, sync, and host forms.

* **Documentation**
  * Updated keyboard hints and help text to reflect the revised navigation shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->