### PR TITLE
fix: stop double-chdir in Homebrew formula templates

### DIFF
--- a/.github/scripts/bump-homebrew-tap-nightly.sh
+++ b/.github/scripts/bump-homebrew-tap-nightly.sh
@@ -81,11 +81,7 @@ class BastNightly < Formula
   end
 
   def install
-    os = OS.mac? ? "darwin" : "linux"
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    cd "bast_#{version}_#{os}_#{arch}" do
-      bin.install "bast"
-    end
+    bin.install "bast"
   end
 
   test do

--- a/.github/scripts/bump-homebrew-tap.sh
+++ b/.github/scripts/bump-homebrew-tap.sh
@@ -81,11 +81,7 @@ class Bast < Formula
   end
 
   def install
-    os = OS.mac? ? "darwin" : "linux"
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-    cd "bast_#{version}_#{os}_#{arch}" do
-      bin.install "bast"
-    end
+    bin.install "bast"
   end
 
   test do


### PR DESCRIPTION
closes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Homebrew installation formulas to reliably install the `bast` command from downloaded packages.
  * Updated both standard and nightly Homebrew packages for more consistent installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->