### PR TITLE
feat: collapse behvaiour rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Groups can nest up to five levels (`Work/Production/web`). Bast stores presentat
 
 `1` hosts · `2` keys · arrows or `j`/`k` to move · `/` search · `r` reload · `v` version info
 
-**Hosts:** Enter connect · `a` add · `e` edit · `d` delete · `f` favorite · `h` hide · `.` show hidden · Space collapse group · `s` sort · `K` drop known-host entry
+**Hosts:** Enter connect · `a` add · `e` edit · `d` delete · `f` favorite · `h` hide · `.` show hidden · Space collapse/expand group · `[` collapse all · `]` expand all · `s` sort · `K` drop known-host entry
 
 **Keys:** `a` generate · `i` import · `e` edit comment · `d` delete · `u` push to server · `x` export · `p` passphrase · `c` copy public key
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -29,7 +29,8 @@ type Host struct {
 }
 
 type Preferences struct {
-	Sort string `json:"sort,omitempty"`
+	Sort            string   `json:"sort,omitempty"`
+	CollapsedGroups []string `json:"collapsedGroups,omitempty"`
 }
 
 type GCPIntegration struct {
@@ -287,13 +288,24 @@ func (s *Store) RecordUse(alias string) error {
 func (s *Store) Preferences() Preferences {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.state.Preferences
+	prefs := s.state.Preferences
+	if prefs.CollapsedGroups != nil {
+		prefs.CollapsedGroups = append([]string(nil), prefs.CollapsedGroups...)
+	}
+	return prefs
 }
 
 func (s *Store) SetSort(sortOrder string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.state.Preferences.Sort = sortOrder
+	return s.save()
+}
+
+func (s *Store) SetCollapsedGroups(groups []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state.Preferences.CollapsedGroups = cleanCollapsedGroups(groups)
 	return s.save()
 }
 
@@ -478,6 +490,21 @@ func cleanTags(tags []string) []string {
 			seen[tag] = true
 			out = append(out, tag)
 		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cleanCollapsedGroups(groups []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(groups))
+	for _, group := range groups {
+		group = strings.TrimSpace(group)
+		if group == "" || seen[group] {
+			continue
+		}
+		seen[group] = true
+		out = append(out, group)
 	}
 	sort.Strings(out)
 	return out

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -24,6 +24,9 @@ func TestStoreRoundTripAndPermissions(t *testing.T) {
 	if err := store.SetSort("group"); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.SetCollapsedGroups([]string{"Work", "Personal", "Work", " "}); err != nil {
+		t.Fatal(err)
+	}
 	reopened, err := Open(path)
 	if err != nil {
 		t.Fatal(err)
@@ -31,6 +34,9 @@ func TestStoreRoundTripAndPermissions(t *testing.T) {
 	host := reopened.Host("prod")
 	if host.Label != "Production web" || !host.Favorite || !host.Hidden || host.ConnectionCount != 1 || len(host.Tags) != 2 || reopened.Preferences().Sort != "group" {
 		t.Fatalf("unexpected state: %+v %+v", host, reopened.Preferences())
+	}
+	if got := reopened.Preferences().CollapsedGroups; !reflect.DeepEqual(got, []string{"Personal", "Work"}) {
+		t.Fatalf("collapsed groups = %v", got)
 	}
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -168,7 +168,7 @@ func New(p paths.Paths, client openssh.Client, version string) (*App, error) {
 		dark:             true,
 		nerdFont:         detectNerdFont(os.Getenv),
 		version:          version,
-		collapsedGroups:  map[string]bool{},
+		collapsedGroups:  collapsedGroupsFromPrefs(store.Preferences().CollapsedGroups),
 		syncingProviders: map[string]bool{},
 	}
 	app.hostMeta, app.hostMetaRevision = store.HostsSnapshot()

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1755,8 +1755,88 @@ func TestEnterTogglesSelectedGroup(t *testing.T) {
 	}
 
 	footer := m.renderFooter(m.styles())
-	if !strings.Contains(footer, "␣ collapse/expand") || strings.Contains(footer, "␣ group") {
+	if !strings.Contains(footer, "␣ collapse") || strings.Contains(footer, "␣ group") {
 		t.Fatalf("footer = %q", footer)
+	}
+	m.updateKeys(enter)
+	footer = m.renderFooter(m.styles())
+	if !strings.Contains(footer, "␣ expand") {
+		t.Fatalf("collapsed footer = %q", footer)
+	}
+}
+
+func TestCollapsedGroupsPersistAcrossSessions(t *testing.T) {
+	home := t.TempDir()
+	p := paths.ForHome(home)
+	store, err := metadata.Open(p.StateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &App{
+		paths: p, openSSH: openssh.Default(), metadata: store,
+		hosts: []sshconfig.Host{{Alias: "alpha"}, {Alias: "beta"}},
+		width: 100, height: 30, dark: true, collapsedGroups: map[string]bool{},
+	}
+	if err := m.metadata.SetHost("alpha", metadata.Host{Group: "Work"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.metadata.SetHost("beta", metadata.Host{Group: "Work"}); err != nil {
+		t.Fatal(err)
+	}
+	m.sortHosts()
+	m.cursor = 0
+	m.updateKeys(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
+	if !m.collapsedGroups["Work"] {
+		t.Fatal("expected Work to be collapsed")
+	}
+	prefs := m.metadata.Preferences().CollapsedGroups
+	if len(prefs) != 1 || prefs[0] != "Work" {
+		t.Fatalf("persisted collapsed groups = %v", prefs)
+	}
+
+	reopened, err := New(p, openssh.Default(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reopened.collapsedGroups["Work"] {
+		t.Fatalf("reopened session lost collapse state: %v", reopened.collapsedGroups)
+	}
+}
+
+func TestCollapseAndExpandAllGroups(t *testing.T) {
+	m := testApp(t)
+	m.hosts = append(m.hosts, sshconfig.Host{Alias: "gamma"})
+	if err := m.metadata.SetHost("alpha", metadata.Host{Group: "Work"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.metadata.SetHost("beta", metadata.Host{Group: "Work"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.metadata.SetHost("gamma", metadata.Host{Group: "Personal"}); err != nil {
+		t.Fatal(err)
+	}
+	m.sortHosts()
+
+	m.updateKeys(tea.KeyPressMsg(tea.Key{Text: "["}))
+	if !m.collapsedGroups["Work"] || !m.collapsedGroups["Personal"] {
+		t.Fatalf("collapse all failed: %v", m.collapsedGroups)
+	}
+	for _, row := range m.hostRows() {
+		if !row.header {
+			t.Fatalf("collapse all still shows host row: %+v", row)
+		}
+	}
+	prefs := m.metadata.Preferences().CollapsedGroups
+	if len(prefs) != 2 || prefs[0] != "Personal" || prefs[1] != "Work" {
+		t.Fatalf("persisted collapse all = %v", prefs)
+	}
+
+	m.updateKeys(tea.KeyPressMsg(tea.Key{Text: "]"}))
+	if len(m.collapsedGroups) != 0 {
+		t.Fatalf("expand all failed: %v", m.collapsedGroups)
+	}
+	if got := m.metadata.Preferences().CollapsedGroups; len(got) != 0 {
+		t.Fatalf("persisted expand all = %v", got)
 	}
 }
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -305,6 +305,14 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.section == hostsSection {
 			return m, m.toggleSelectedGroup()
 		}
+	case "[":
+		if m.section == hostsSection {
+			return m, m.collapseAllGroups()
+		}
+	case "]":
+		if m.section == hostsSection {
+			return m, m.expandAllGroups()
+		}
 	case "a":
 		if m.section == syncSection {
 			return m, nil

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -432,6 +432,9 @@ func (m *App) renameGroup(oldPath, newSegment string) (string, error) {
 		}
 		m.collapsedGroups = updated
 		m.collapseRevision++
+		if err := m.persistCollapsedGroups(); err != nil {
+			return "", err
+		}
 	}
 	m.refreshHostMetadata()
 	return normalized, nil
@@ -537,7 +540,11 @@ func (m *App) toggleSelectedGroup() tea.Cmd {
 	if m.collapsedGroups == nil {
 		m.collapsedGroups = map[string]bool{}
 	}
-	m.collapsedGroups[group] = !m.collapsedGroups[group]
+	if m.collapsedGroups[group] {
+		delete(m.collapsedGroups, group)
+	} else {
+		m.collapsedGroups[group] = true
+	}
 	m.collapseRevision++
 	for i, row := range m.hostRows() {
 		if row.header && row.group == group {
@@ -545,8 +552,73 @@ func (m *App) toggleSelectedGroup() tea.Cmd {
 			break
 		}
 	}
+	if err := m.persistCollapsedGroups(); err != nil {
+		m.setError(err)
+	}
 	return nil
 }
+
+func (m *App) collapseAllGroups() tea.Cmd {
+	if m.searchText() != "" {
+		return m.setNotice("Clear the search filter to collapse groups")
+	}
+	m.collapsedGroups = map[string]bool{}
+	m.collapseRevision++
+	for _, row := range m.hostRows() {
+		if row.header {
+			m.collapsedGroups[row.group] = true
+		}
+	}
+	m.collapseRevision++
+	m.clampCursor()
+	if err := m.persistCollapsedGroups(); err != nil {
+		m.setError(err)
+		return nil
+	}
+	return nil
+}
+
+func (m *App) expandAllGroups() tea.Cmd {
+	m.collapsedGroups = map[string]bool{}
+	m.collapseRevision++
+	if err := m.persistCollapsedGroups(); err != nil {
+		m.setError(err)
+		return nil
+	}
+	return nil
+}
+
+func (m *App) persistCollapsedGroups() error {
+	groups := make([]string, 0, len(m.collapsedGroups))
+	for path, collapsed := range m.collapsedGroups {
+		if collapsed {
+			groups = append(groups, path)
+		}
+	}
+	return m.metadata.SetCollapsedGroups(groups)
+}
+
+func collapsedGroupsFromPrefs(groups []string) map[string]bool {
+	out := make(map[string]bool, len(groups))
+	for _, group := range groups {
+		if group != "" {
+			out[group] = true
+		}
+	}
+	return out
+}
+
+func (m *App) collapseActionLabel() string {
+	group, ok := m.selectedGroup()
+	if !ok {
+		return "collapse"
+	}
+	if m.collapsedGroups[group] {
+		return "expand"
+	}
+	return "collapse"
+}
+
 func (m *App) searchText() string { return strings.TrimPrefix(m.search, "\x00") }
 func (m *App) setError(err error) {
 	m.statusID++

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -433,7 +433,7 @@ func (m *App) renameGroup(oldPath, newSegment string) (string, error) {
 		m.collapsedGroups = updated
 		m.collapseRevision++
 		if err := m.persistCollapsedGroups(); err != nil {
-			return "", err
+			m.setError(err)
 		}
 	}
 	m.refreshHostMetadata()

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -221,9 +221,9 @@ func (m *App) renderGroupDetail(s styleSet, row hostRow, width int) string {
 			state = "expanded for search"
 		}
 	}
-	hint := "␣ collapse/expand · e rename"
+	hint := "␣ " + m.collapseActionLabel() + " · e rename"
 	if sync.IsSyncedGroup(row.group) {
-		hint = "␣ collapse/expand · cloud sync (read-only)"
+		hint = "␣ " + m.collapseActionLabel() + " · cloud sync (read-only)"
 	}
 	iconWidth := lipgloss.Width(managedGroupIcon(row.group, m.nerdFont))
 	name := truncate(row.group, max(2, width-3-iconWidth))
@@ -584,7 +584,7 @@ func contrastingTextColor(background string) (string, bool) {
 }
 
 func (m *App) renderHelp(s styleSet) string {
-	lines := []string{"Navigation", "  ↑/↓ or j/k  move       /  search       r  reload", "  1  hosts       2  keys   3  sync   ?  help         v  about       q  quit", "", "Hosts", "  󰌑 connect      a add     e edit         d delete", "  ␣ collapse/expand                        s sort", "  f favorite      h hide/show selected     . toggle hidden hosts", "  K remove known-host entry", "", "Keys", "  a generate      i import  e edit comment d delete", "  u add to server x export  p change passphrase       c copy public key", "", "Sync", "  󰌑 open provider / run action   Esc back   r refresh", "", "During SSH", "  exit returns to Bast; press 󰌑 then ~. to force-close a stuck session"}
+	lines := []string{"Navigation", "  ↑/↓ or j/k  move       /  search       r  reload", "  1  hosts       2  keys   3  sync   ?  help         v  about       q  quit", "", "Hosts", "  󰌑 connect      a add     e edit         d delete", "  ␣ collapse/expand   [ collapse all   ] expand all  s sort", "  f favorite      h hide/show selected     . toggle hidden hosts", "  K remove known-host entry", "", "Keys", "  a generate      i import  e edit comment d delete", "  u add to server x export  p change passphrase       c copy public key", "", "Sync", "  󰌑 open provider / run action   Esc back   r refresh", "", "During SSH", "  exit returns to Bast; press 󰌑 then ~. to force-close a stuck session"}
 	return "\n  " + s.active.Render("Keyboard help") + "\n\n" + strings.Join(lines, "\n") + "\n\n  " + s.muted.Render("Press ?, Esc, or ⌫ to close")
 }
 
@@ -653,16 +653,17 @@ func (m *App) renderFooter(s styleSet) string {
 	if m.form != nil {
 		hint = m.formHint()
 	} else if m.section == hostsSection {
+		collapse := "␣ " + m.collapseActionLabel()
 		if _, groupSelected := m.selectedGroupHeader(); groupSelected {
 			if m.isMobileLayout() {
-				hint = "↑/↓ or j/k move • e rename • ␣ collapse/expand • a add • v about • ? help"
+				hint = "↑/↓ or j/k move • e rename • " + collapse + " • a add • v about • ? help"
 			} else {
-				hint = "␣ collapse/expand • e rename • a add • v about • ? help"
+				hint = collapse + " • e rename • a add • v about • ? help"
 			}
 		} else if m.isMobileLayout() {
 			hint = "↑/↓ or j/k move • click Connect • a add • v about • ? help"
 		} else {
-			hint = "󰌑 connect • ␣ collapse/expand • a add • h hide • v about • ? help"
+			hint = "󰌑 connect • " + collapse + " • a add • h hide • v about • ? help"
 		}
 	} else if m.section == keysSection {
 		hint = "a generate • i import • u add to server • x export • v about • ? help"


### PR DESCRIPTION
closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host groups now remember their collapsed or expanded state between sessions.
  * Added keyboard shortcuts to collapse all groups (`[`) or expand all groups (`]`).
  * Updated on-screen controls to reflect the available collapse and expand actions.
  * Renaming a group now preserves its collapse state.

* **Documentation**
  * Updated the keyboard shortcuts documentation with the new group controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->