### PR TITLE
feat: error tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Anonymous usage telemetry (version, platform, events) is on by default. Opt out:
 export BAST_NO_TELEMETRY=1
 ```
 
-When an error occurs in an interactive session, Bast can offer to send an anonymous error report (Space to send, any other key to continue). Reports may include the error text shown on screen. SSH session endings are not reported. `BAST_NO_TELEMETRY=1` disables both usage telemetry and error reports.
+When an error occurs in an interactive session, Bast can offer to send an error report that may include error text and stack traces. In the TUI error overlay, Space sends the report; Enter, Esc, Backspace, and Ctrl+H dismiss it; q quits; unrelated keys leave it open. SSH session endings are not reported. `BAST_NO_TELEMETRY=1` disables both usage telemetry and error reports.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Anonymous usage telemetry (version, platform, events) is on by default. Opt out:
 export BAST_NO_TELEMETRY=1
 ```
 
+When an error occurs in an interactive session, Bast can offer to send an anonymous error report (Space to send, any other key to continue). Reports may include the error text shown on screen. SSH session endings are not reported. `BAST_NO_TELEMETRY=1` disables both usage telemetry and error reports.
+
 ## Development
 
 ```sh

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,11 +15,14 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/charmbracelet/x/term"
+
 	"bast/internal/keys"
 	"bast/internal/metadata"
 	"bast/internal/openssh"
 	"bast/internal/paths"
 	"bast/internal/sshconfig"
+	"bast/internal/telemetry"
 )
 
 const help = `Bast — native SSH picker, key manager, and CLI
@@ -169,6 +172,16 @@ func (r *Runner) Run(args []string) error {
 		_ = json.NewEncoder(r.Err).Encode(map[string]any{"ok": false, "error": map[string]string{"code": ce.code, "message": ce.message}})
 	} else {
 		fmt.Fprintln(r.Err, "bast:", ce.message)
+		if !r.NoInput && telemetry.Enabled() {
+			if in, ok := r.In.(*os.File); ok && term.IsTerminal(in.Fd()) {
+				telemetry.OfferReport(r.In, r.Err, telemetry.Report{
+					Message: ce.message,
+					Version: r.Version,
+					Code:    ce.code,
+					Context: "cli",
+				})
+			}
+		}
 	}
 	return reportedError{code: ce.exit}
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,15 +3,31 @@ package telemetry
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
 	"time"
+
+	"github.com/charmbracelet/x/term"
 )
 
-const defaultEndpoint = "https://bast.sh/api/telemetry"
+const (
+	defaultEndpoint      = "https://bast.sh/api/telemetry"
+	defaultErrorEndpoint = "https://bast.sh/api/errors"
+)
 
-var endpoint = defaultEndpoint
+var (
+	endpoint      = defaultEndpoint
+	errorEndpoint = defaultErrorEndpoint
+)
+
+// SetErrorEndpoint overrides the error report URL. Returns a restore function for tests.
+func SetErrorEndpoint(url string) func() {
+	prev := errorEndpoint
+	errorEndpoint = url
+	return func() { errorEndpoint = prev }
+}
 
 type payload struct {
 	Event   string `json:"event"`
@@ -20,6 +36,23 @@ type payload struct {
 	Arch    string `json:"arch"`
 	Source  string `json:"source"`
 }
+
+// Report is a consented error payload sent to bast-web for Sentry/Better Stack.
+type Report struct {
+	Message string `json:"message"`
+	Version string `json:"version"`
+	OS      string `json:"os"`
+	Arch    string `json:"arch"`
+	Source  string `json:"source"`
+	Code    string `json:"code,omitempty"`
+	Stack   string `json:"stack,omitempty"`
+	Context string `json:"context,omitempty"`
+	Command string `json:"command,omitempty"`
+}
+
+const (
+	ReportPrompt = "\r\n\x1b[38;2;107;114;128m Press Space to send an anonymous error report, any other key to continue.\x1b[0m\r\n"
+)
 
 func Enabled() bool {
 	return os.Getenv("BAST_NO_TELEMETRY") == ""
@@ -31,6 +64,57 @@ func Track(event, version string) {
 	}
 
 	go send(event, version)
+}
+
+func ReportError(r Report) {
+	if !Enabled() {
+		return
+	}
+	if r.Message == "" {
+		return
+	}
+	if r.OS == "" {
+		r.OS = platformOS()
+	}
+	if r.Arch == "" {
+		r.Arch = platformArch()
+	}
+	if r.Source == "" {
+		r.Source = "cli"
+	}
+	// Synchronous so consented reports flush before process exit.
+	sendError(r)
+}
+
+// OfferReport prints ReportPrompt and sends Report when the user presses Space.
+// Skips when telemetry is disabled or in is not usable.
+func OfferReport(in io.Reader, out io.Writer, r Report) {
+	if !Enabled() {
+		return
+	}
+	if out != nil {
+		_, _ = io.WriteString(out, ReportPrompt)
+	}
+	if in == nil {
+		return
+	}
+
+	file, ok := in.(*os.File)
+	if ok && term.IsTerminal(file.Fd()) {
+		state, err := term.MakeRaw(file.Fd())
+		if err == nil {
+			defer func() { _ = term.Restore(file.Fd(), state) }()
+		}
+	}
+
+	var buf [1]byte
+	n, err := in.Read(buf[:])
+	if err != nil || n == 0 {
+		return
+	}
+	if buf[0] == ' ' {
+		ReportError(r)
+	}
 }
 
 func send(event, version string) {
@@ -46,6 +130,26 @@ func send(event, version string) {
 	}
 
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+}
+
+func sendError(r Report) {
+	body, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, errorEndpoint, bytes.NewReader(body))
 	if err != nil {
 		return
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -51,7 +51,7 @@ type Report struct {
 }
 
 const (
-	ReportPrompt = "\r\n\x1b[38;2;107;114;128m Press Space to send an anonymous error report, any other key to continue.\x1b[0m\r\n"
+	ReportPrompt = "\r\n\x1b[38;2;107;114;128m Press Space to send an error report (may include error text and stack traces), any other key to continue.\x1b[0m\r\n"
 )
 
 func Enabled() bool {
@@ -108,8 +108,8 @@ func OfferReport(in io.Reader, out io.Writer, r Report) {
 	}
 
 	var buf [1]byte
-	n, err := in.Read(buf[:])
-	if err != nil || n == 0 {
+	n, _ := in.Read(buf[:])
+	if n == 0 {
 		return
 	}
 	if buf[0] == ' ' {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -82,3 +83,125 @@ func TestTrackSkipsWhenDisabled(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 }
+
+func TestReportErrorSendsPayload(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "")
+
+	got := make(chan Report, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body Report
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		got <- body
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	original := errorEndpoint
+	errorEndpoint = server.URL
+	t.Cleanup(func() { errorEndpoint = original })
+
+	ReportError(Report{
+		Message: "boom",
+		Version: "v1.2.3",
+		Code:    "operation_failed",
+		Context: "cli",
+	})
+
+	select {
+	case body := <-got:
+		if body.Message != "boom" || body.Version != "v1.2.3" || body.Source != "cli" || body.Code != "operation_failed" || body.Context != "cli" {
+			t.Fatalf("unexpected payload: %+v", body)
+		}
+		if body.OS == "" || body.Arch == "" {
+			t.Fatalf("expected platform fields, got %+v", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error report")
+	}
+}
+
+func TestReportErrorSkipsWhenDisabled(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "1")
+
+	called := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	original := errorEndpoint
+	errorEndpoint = server.URL
+	t.Cleanup(func() { errorEndpoint = original })
+
+	ReportError(Report{Message: "boom", Version: "v1.2.3"})
+
+	select {
+	case <-called:
+		t.Fatal("error report sent while disabled")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestOfferReportSendsOnSpace(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "")
+
+	got := make(chan Report, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body Report
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		got <- body
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	original := errorEndpoint
+	errorEndpoint = server.URL
+	t.Cleanup(func() { errorEndpoint = original })
+
+	var out strings.Builder
+	OfferReport(strings.NewReader(" "), &out, Report{Message: "fail", Version: "v1.2.3", Context: "tui"})
+	if !strings.Contains(out.String(), "Press Space to send") {
+		t.Fatalf("missing prompt: %q", out.String())
+	}
+
+	select {
+	case body := <-got:
+		if body.Message != "fail" || body.Context != "tui" {
+			t.Fatalf("unexpected payload: %+v", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error report")
+	}
+}
+
+func TestOfferReportSkipsSendOnOtherKey(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "")
+
+	called := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	original := errorEndpoint
+	errorEndpoint = server.URL
+	t.Cleanup(func() { errorEndpoint = original })
+
+	OfferReport(strings.NewReader("k"), ioDiscard{}, Report{Message: "fail", Version: "v1.2.3"})
+
+	select {
+	case <-called:
+		t.Fatal("error report sent without Space")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -318,6 +318,18 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.String() {
 			case "q":
 				return m, tea.Quit
+			case "space":
+				if telemetry.Enabled() {
+					telemetry.ReportError(telemetry.Report{
+						Message: m.status,
+						Version: m.version,
+						Context: "tui",
+					})
+					return m, m.setNotice("Report sent")
+				}
+				m.statusID++
+				m.status, m.statusError = "", false
+				return m, nil
 			case "enter", "esc", "backspace", "ctrl+h":
 				m.statusID++
 				m.status, m.statusError = "", false

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1179,6 +1179,7 @@ func TestSSHProcessPausesOnFailure(t *testing.T) {
 }
 
 func TestSSHProcessPausesOnPrepareFailure(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "")
 	var output bytes.Buffer
 	cmd := exec.Command("/bin/sh", "-c", "printf should-not-run")
 	cmd.Stdout = &output

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2,8 +2,11 @@ package ui
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +24,7 @@ import (
 	"bast/internal/openssh"
 	"bast/internal/paths"
 	"bast/internal/sshconfig"
+	"bast/internal/telemetry"
 )
 
 func testApp(t *testing.T) *App {
@@ -1191,12 +1195,12 @@ func TestSSHProcessPausesOnPrepareFailure(t *testing.T) {
 	if strings.Contains(got, "should-not-run") {
 		t.Fatal("ssh should not run after prepare failure")
 	}
-	if !strings.Contains(got, connectbanner.ContinuePrompt) {
-		t.Fatalf("missing continue prompt after prepare failure:\n%q", got)
+	if !strings.Contains(got, telemetry.ReportPrompt) {
+		t.Fatalf("missing error report prompt after prepare failure:\n%q", got)
 	}
 	failure := "Connection failed: gcp access denied"
-	if !strings.Contains(got, failure) || strings.Index(got, failure) > strings.Index(got, connectbanner.ContinuePrompt) {
-		t.Fatalf("prepare error should appear before the continue prompt:\n%q", got)
+	if !strings.Contains(got, failure) || strings.Index(got, failure) > strings.Index(got, telemetry.ReportPrompt) {
+		t.Fatalf("prepare error should appear before the report prompt:\n%q", got)
 	}
 }
 
@@ -1280,7 +1284,7 @@ func TestErrorsUseAProminentScreenAndPreserveTheForm(t *testing.T) {
 	}
 
 	rendered := m.render()
-	for _, expected := range []string{"Action failed", "What happened", "Delete host — alpha failed", "confirmation did not match", "Your entries are still"} {
+	for _, expected := range []string{"Action failed", "What happened", "Delete host — alpha failed", "confirmation did not match", "Your entries are still", "Space send report"} {
 		if !strings.Contains(rendered, expected) {
 			t.Fatalf("prominent error screen is missing %q:\n%s", expected, rendered)
 		}
@@ -1299,6 +1303,46 @@ func TestErrorsUseAProminentScreenAndPreserveTheForm(t *testing.T) {
 	}
 	if !strings.Contains(m.render(), "Type the name to confirm") {
 		t.Fatal("the retained form was not restored")
+	}
+}
+
+func TestErrorOverlaySpaceSendsReport(t *testing.T) {
+	t.Setenv("BAST_NO_TELEMETRY", "")
+
+	got := make(chan telemetry.Report, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body telemetry.Report
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		got <- body
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	t.Cleanup(telemetry.SetErrorEndpoint(server.URL))
+
+	m := testApp(t)
+	m.version = "v1.2.3"
+	m.status, m.statusError = "sync failed", true
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
+	if m.statusError || m.status != "Report sent" {
+		t.Fatalf("Space should send report and show notice: status=%q error=%v", m.status, m.statusError)
+	}
+
+	select {
+	case body := <-got:
+		if body.Message != "sync failed" || body.Context != "tui" || body.Version != "v1.2.3" {
+			t.Fatalf("unexpected report: %+v", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for error report")
+	}
+
+	t.Setenv("BAST_NO_TELEMETRY", "1")
+	m.status, m.statusError = "sync failed", true
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeySpace, Text: " "}))
+	if m.statusError || m.status != "" {
+		t.Fatalf("Space with telemetry disabled should dismiss: status=%q error=%v", m.status, m.statusError)
 	}
 }
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -20,6 +20,7 @@ import (
 type connectionProcess struct {
 	cmd     *exec.Cmd
 	prepare func(status func(string)) error
+	version string
 }
 
 func (c *connectionProcess) Run() error {
@@ -35,7 +36,15 @@ func (c *connectionProcess) Run() error {
 	if c.prepare != nil {
 		if err := c.prepare(connectbanner.Status(output)); err != nil {
 			_, _ = fmt.Fprintf(output, "\r\nConnection failed: %v\r\n", err)
-			connectbanner.WaitToContinue(input, output)
+			if telemetry.Enabled() {
+				telemetry.OfferReport(input, output, telemetry.Report{
+					Message: err.Error(),
+					Version: c.version,
+					Context: "connect_prepare",
+				})
+			} else {
+				connectbanner.WaitToContinue(input, output)
+			}
 			return fmt.Errorf("prepare connection: %w", err)
 		}
 		_, _ = io.WriteString(output, "\r\n")
@@ -487,7 +496,7 @@ func (m *App) startSSH(host sshconfig.Host, prepare func(func(string)) error) (t
 	}
 	telemetry.Track("connect", m.version)
 	m.status = "Connected to " + m.hostLabel(host) + "; exit returns to Bast; 󰌑 then ~. force-closes SSH"
-	return m, tea.Exec(&connectionProcess{cmd: cmd, prepare: prepare}, func(err error) tea.Msg {
+	return m, tea.Exec(&connectionProcess{cmd: cmd, prepare: prepare, version: m.version}, func(err error) tea.Msg {
 		return processDoneMsg{name: "SSH session", err: err, sshSession: true}
 	})
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -11,6 +11,7 @@ import (
 	"bast/internal/cloud/sync"
 	"bast/internal/keys"
 	"bast/internal/sshconfig"
+	"bast/internal/telemetry"
 )
 
 const (
@@ -68,11 +69,15 @@ func (m *App) renderError(s styleSet) string {
 	if m.form != nil {
 		explanation += " Your entries are still available when you return."
 	}
+	footer := "Enter/Esc return"
+	if telemetry.Enabled() {
+		footer = "Space send report · Enter/Esc return"
+	}
 	content := s.error.Bold(true).Render("✕  Action failed") +
 		"\n\n" + s.muted.Render("What happened") +
 		"\n" + s.value.Width(contentWidth).Render(m.status) +
 		"\n\n" + s.muted.Width(contentWidth).Render(explanation) +
-		"\n\n" + s.muted.Render("Space send report · Enter/Esc return")
+		"\n\n" + s.muted.Render(footer)
 	panel := lipgloss.NewStyle().
 		Width(contentWidth).
 		Padding(1, 2).

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -72,7 +72,7 @@ func (m *App) renderError(s styleSet) string {
 		"\n\n" + s.muted.Render("What happened") +
 		"\n" + s.value.Width(contentWidth).Render(m.status) +
 		"\n\n" + s.muted.Width(contentWidth).Render(explanation) +
-		"\n\n" + s.muted.Render("Press Enter or Esc to return")
+		"\n\n" + s.muted.Render("Space send report · Enter/Esc return")
 	panel := lipgloss.NewStyle().
 		Width(contentWidth).
 		Padding(1, 2).

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/term"
 
 	"bast/internal/cli"
 	azurecloud "bast/internal/cloud/azure"
@@ -23,11 +24,36 @@ import (
 var version = "dev"
 
 func main() {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+		stack := string(debug.Stack())
+		fmt.Fprintf(os.Stderr, "bast: panic: %v\n%s", recovered, stack)
+		if telemetry.Enabled() && term.IsTerminal(os.Stdin.Fd()) {
+			telemetry.OfferReport(os.Stdin, os.Stderr, telemetry.Report{
+				Message: fmt.Sprint(recovered),
+				Version: buildVersion(),
+				Stack:   stack,
+				Context: "panic",
+			})
+		}
+		os.Exit(2)
+	}()
+
 	if err := run(os.Args[1:]); err != nil {
 		if code, ok := cli.ExitCode(err); ok {
 			os.Exit(code)
 		}
 		fmt.Fprintln(os.Stderr, "bast:", err)
+		if telemetry.Enabled() && term.IsTerminal(os.Stdin.Fd()) {
+			telemetry.OfferReport(os.Stdin, os.Stderr, telemetry.Report{
+				Message: err.Error(),
+				Version: buildVersion(),
+				Context: "cli",
+			})
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.ExitCode())


### PR DESCRIPTION
closes #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional anonymous error reporting for interactive CLI, connection, and application errors.
  * Users can press Space to send the displayed error, while standard dismissal controls remain available.
  * Added panic and command-line error reporting when running interactively.

* **Documentation**
  * Clarified that reports may include on-screen error text and that `BAST_NO_TELEMETRY=1` disables usage telemetry and error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->