### PR TITLE
feat: label group work

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Bast is a terminal UI for the SSH config and keys you already have. It reads `~/
 
 You can generate and manage keys, push public keys to servers, and do most of it from the CLI if you'd rather skip the TUI.
 
-Groups can nest up to five levels (`Work/Production/web`). Bast stores presentation metadata in `~/.config/bast`. OpenSSH stays the source of truth for hosts and keys.
+Groups can nest up to five levels. Set them in the label with a path (`Work/Production/web` puts the host in `Work/Production` and names it `web`). In the TUI, the inactive Label row shows just the name; focusing it reveals the full path, with the group prefix muted until the cursor moves into it. `--group` remains available on the CLI. Bast stores presentation metadata in `~/.config/bast`. OpenSSH stays the source of truth for hosts and keys.
 
 ## Requirements
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -184,7 +184,7 @@ Connection: --user, --port, --identity, --password-only, --proxy-jump
 Advanced: --forward-agent, --startup-command, --request-tty, --set-env,
           --local-forward, --remote-forward, --dynamic-forward, --compression,
           --keepalive, --ssh-option
-Metadata: --group, --tag, --environment, --color, --notes`,
+Metadata: label paths like Work/api set the group; or --group, --tag, --environment, --color, --notes`,
 		"hosts edit": `Usage: bast hosts edit <host> [options]
 
 Connection: --label, --hostname, --user, --port, --identity, --password-only,
@@ -192,7 +192,8 @@ Connection: --label, --hostname, --user, --port, --identity, --password-only,
 Advanced: --forward-agent, --startup-command, --request-tty, --set-env,
           --local-forward, --remote-forward, --dynamic-forward, --compression,
           --keepalive, --ssh-option
-Metadata: --group, --tag, --environment, --color, --notes
+Metadata: --label paths like Work/api set the group; or --group, --tag,
+          --environment, --color, --notes
 Repeat list options to provide multiple values. Use the corresponding --clear-*
 option to restore a default or remove values.`,
 		"hosts delete":    "Usage: bast hosts delete <host> [--yes]",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -61,6 +61,40 @@ func TestHostAddLabelPathSetsGroup(t *testing.T) {
 	}
 }
 
+func TestHostEditPlainLabelPreservesGroup(t *testing.T) {
+	home := t.TempDir()
+	client := fakeOpenSSH(t)
+	_, errOut, err := runTestCLI(t, home, client, "--json", "hosts", "add", "abc/test", "--hostname", "test.example")
+	if err != nil || errOut != "" {
+		t.Fatalf("add stderr=%q err=%v", errOut, err)
+	}
+	out, errOut, err := runTestCLI(t, home, client, "--json", "hosts", "edit", "test", "--label", "renamed")
+	if err != nil || errOut != "" || !strings.Contains(out, `"ok":true`) {
+		t.Fatalf("edit output=%q stderr=%q err=%v", out, errOut, err)
+	}
+	out, _, err = runTestCLI(t, home, client, "--json", "hosts", "show", "renamed")
+	if err != nil || !strings.Contains(out, `"group":"abc"`) || !strings.Contains(out, `"label":"renamed"`) {
+		t.Fatalf("show output=%q err=%v", out, err)
+	}
+}
+
+func TestHostEditLabelPathWithExplicitGroupPeelsLeaf(t *testing.T) {
+	home := t.TempDir()
+	client := fakeOpenSSH(t)
+	_, errOut, err := runTestCLI(t, home, client, "--json", "hosts", "add", "old", "--hostname", "old.example", "--group", "Legacy")
+	if err != nil || errOut != "" {
+		t.Fatalf("add stderr=%q err=%v", errOut, err)
+	}
+	out, errOut, err := runTestCLI(t, home, client, "--json", "hosts", "edit", "old", "--label", "abc/test", "--group", "Work")
+	if err != nil || errOut != "" || !strings.Contains(out, `"ok":true`) {
+		t.Fatalf("edit output=%q stderr=%q err=%v", out, errOut, err)
+	}
+	out, _, err = runTestCLI(t, home, client, "--json", "hosts", "show", "test")
+	if err != nil || !strings.Contains(out, `"group":"Work"`) || !strings.Contains(out, `"label":"test"`) {
+		t.Fatalf("show output=%q err=%v", out, err)
+	}
+}
+
 func TestExternalHostAllowsMetadataOnlyEdit(t *testing.T) {
 	home := t.TempDir()
 	sshDir := filepath.Join(home, ".ssh")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -48,6 +48,19 @@ func TestHostCommandsRoundTripWithJSON(t *testing.T) {
 	}
 }
 
+func TestHostAddLabelPathSetsGroup(t *testing.T) {
+	home := t.TempDir()
+	client := fakeOpenSSH(t)
+	out, errOut, err := runTestCLI(t, home, client, "--json", "hosts", "add", "abc/test", "--hostname", "test.example")
+	if err != nil || errOut != "" || !strings.Contains(out, `"alias":"test"`) {
+		t.Fatalf("add output=%q stderr=%q err=%v", out, errOut, err)
+	}
+	out, _, err = runTestCLI(t, home, client, "--json", "hosts", "show", "test")
+	if err != nil || !strings.Contains(out, `"group":"abc"`) || !strings.Contains(out, `"label":"test"`) {
+		t.Fatalf("show output=%q err=%v", out, err)
+	}
+}
+
 func TestExternalHostAllowsMetadataOnlyEdit(t *testing.T) {
 	home := t.TempDir()
 	sshDir := filepath.Join(home, ".ssh")

--- a/internal/cli/hosts.go
+++ b/internal/cli/hosts.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"strings"
 	"time"
@@ -179,15 +180,19 @@ func (r *Runner) hostAdd(args []string) error {
 		}
 	}
 	var adv sshconfig.AdvancedSettings
+	groupPrompted := false
 	if wizard && r.interactive() && !r.NoInput {
 		adv, err = promptAdvancedSettings(r, sshconfig.AdvancedSettings{ProxyJump: *proxy})
 		if err != nil {
 			return err
 		}
 		*proxy = adv.ProxyJump
-		*group, err = r.prompt("Group", *group, false)
-		if err != nil {
-			return err
+		if !strings.Contains(label, "/") {
+			*group, err = r.prompt("Group", *group, false)
+			if err != nil {
+				return err
+			}
+			groupPrompted = true
 		}
 		tagText, promptErr := r.prompt("Tags (comma separated)", strings.Join(tags, ", "), false)
 		if promptErr != nil {
@@ -210,7 +215,13 @@ func (r *Runner) hostAdd(args []string) error {
 	if *identity != "" && *passwordOnly {
 		return usagef("--identity and --password-only cannot be used together")
 	}
-	normalizedGroup, err := normalizeGroup(*group)
+	groupFlagSet := groupPrompted
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "group" {
+			groupFlagSet = true
+		}
+	})
+	leaf, normalizedGroup, err := resolveLabelAndGroup(label, groupFlagSet, *group, false)
 	if err != nil {
 		return err
 	}
@@ -221,14 +232,14 @@ func (r *Runner) hostAdd(args []string) error {
 		}
 	}
 	input := hostInputFromAdvanced(sshconfig.HostInput{
-		Alias: sshconfig.NormalizeAlias(strings.TrimSpace(label)), HostName: *hostname, User: *user, Port: *port,
+		Alias: sshconfig.NormalizeAlias(leaf), HostName: *hostname, User: *user, Port: *port,
 		IdentityFile: *identity, PasswordOnly: *passwordOnly,
 	}, adv)
 	host, err := r.config.Add(input)
 	if err != nil {
 		return err
 	}
-	meta := metadata.Host{Label: strings.TrimSpace(label), Group: normalizedGroup, Tags: splitValues(tags), Environment: *environment, Color: *color, Notes: *notes}
+	meta := metadata.Host{Label: leaf, Group: normalizedGroup, Tags: splitValues(tags), Environment: *environment, Color: *color, Notes: *notes}
 	if meta.Label == input.Alias {
 		meta.Label = ""
 	}
@@ -301,7 +312,7 @@ func (r *Runner) hostEdit(args []string) error {
 		if r.NoInput || !r.interactive() {
 			return usagef("no changes supplied")
 		}
-		label.value, err = r.prompt("Label", host.Label, true)
+		label.value, err = r.prompt("Label", metadata.JoinLabelPath(host.Group, host.Label), true)
 		if err != nil {
 			return err
 		}
@@ -351,11 +362,13 @@ func (r *Runner) hostEdit(args []string) error {
 			wizardAdvanced = &nextAdv
 			proxy.value, proxy.set = nextAdv.ProxyJump, true
 		}
-		group.value, err = r.prompt("Group", host.Group, false)
-		if err != nil {
-			return err
+		if !strings.Contains(label.value, "/") {
+			group.value, err = r.prompt("Group", host.Group, false)
+			if err != nil {
+				return err
+			}
+			group.set = true
 		}
-		group.set = true
 		tagText, promptErr := r.prompt("Tags (comma separated)", strings.Join(host.Tags, ", "), false)
 		if promptErr != nil {
 			return promptErr
@@ -393,10 +406,17 @@ func (r *Runner) hostEdit(args []string) error {
 	newAlias := host.Alias
 	newMeta := host.meta
 	if label.set {
-		if host.Managed {
-			newAlias = sshconfig.NormalizeAlias(strings.TrimSpace(label.value))
+		leaf, parsedGroup, pathErr := resolveLabelAndGroup(label.value, group.set, group.value, *clearGroup)
+		if pathErr != nil {
+			return pathErr
 		}
-		newMeta.Label = strings.TrimSpace(label.value)
+		if host.Managed {
+			newAlias = sshconfig.NormalizeAlias(leaf)
+		}
+		newMeta.Label = leaf
+		if !group.set && !*clearGroup {
+			newMeta.Group = parsedGroup
+		}
 	}
 	if group.set {
 		newMeta.Group, err = normalizeGroup(group.value)
@@ -686,21 +706,42 @@ func (r *Runner) connect(args []string) error {
 }
 
 func normalizeGroup(group string) (string, error) {
-	group = strings.TrimSpace(group)
-	if group == "" {
-		return "", nil
+	normalized, err := metadata.NormalizeGroupPath(group)
+	if err != nil {
+		return "", fail("validation", err.Error())
 	}
-	parts := strings.Split(group, "/")
-	if len(parts) > 5 {
-		return "", fail("validation", "groups can be at most 5 levels deep")
-	}
-	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
-		if parts[i] == "" {
-			return "", fail("validation", "group levels cannot be empty")
+	return normalized, nil
+}
+
+// resolveLabelAndGroup applies path-in-label parsing when --group was not set.
+// Explicit group keeps the label literal. clear-group still peels a path leaf.
+func resolveLabelAndGroup(label string, groupSet bool, groupValue string, clearGroup bool) (leaf, group string, err error) {
+	label = strings.TrimSpace(label)
+	if clearGroup {
+		if strings.Contains(label, "/") {
+			_, leaf, err = metadata.SplitLabelPath(label)
+			if err != nil {
+				return "", "", fail("validation", err.Error())
+			}
+			return leaf, "", nil
 		}
+		return label, "", nil
 	}
-	return strings.Join(parts, "/"), nil
+	if groupSet {
+		group, err = normalizeGroup(groupValue)
+		if err != nil {
+			return "", "", err
+		}
+		return label, group, nil
+	}
+	if strings.Contains(label, "/") {
+		group, leaf, err = metadata.SplitLabelPath(label)
+		if err != nil {
+			return "", "", fail("validation", err.Error())
+		}
+		return leaf, group, nil
+	}
+	return label, "", nil
 }
 
 func splitValues(values []string) []string {

--- a/internal/cli/hosts.go
+++ b/internal/cli/hosts.go
@@ -414,7 +414,9 @@ func (r *Runner) hostEdit(args []string) error {
 			newAlias = sshconfig.NormalizeAlias(leaf)
 		}
 		newMeta.Label = leaf
-		if !group.set && !*clearGroup {
+		// Only apply a group from the label when the label carries path info.
+		// A plain label rename must preserve the existing host group.
+		if !group.set && !*clearGroup && strings.Contains(strings.TrimSpace(label.value), "/") {
 			newMeta.Group = parsedGroup
 		}
 	}
@@ -713,8 +715,9 @@ func normalizeGroup(group string) (string, error) {
 	return normalized, nil
 }
 
-// resolveLabelAndGroup applies path-in-label parsing when --group was not set.
-// Explicit group keeps the label literal. clear-group still peels a path leaf.
+// resolveLabelAndGroup peels path-in-label syntax into a leaf name.
+// Explicit --group overrides only the group; a path in the label still peels.
+// clear-group clears the group and still peels a path leaf when present.
 func resolveLabelAndGroup(label string, groupSet bool, groupValue string, clearGroup bool) (leaf, group string, err error) {
 	label = strings.TrimSpace(label)
 	if clearGroup {
@@ -731,6 +734,13 @@ func resolveLabelAndGroup(label string, groupSet bool, groupValue string, clearG
 		group, err = normalizeGroup(groupValue)
 		if err != nil {
 			return "", "", err
+		}
+		if strings.Contains(label, "/") {
+			_, leaf, err = metadata.SplitLabelPath(label)
+			if err != nil {
+				return "", "", fail("validation", err.Error())
+			}
+			return leaf, group, nil
 		}
 		return label, group, nil
 	}

--- a/internal/metadata/label_path.go
+++ b/internal/metadata/label_path.go
@@ -1,0 +1,95 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+)
+
+const MaxGroupDepth = 5
+
+// NormalizeGroupPath trims and validates a slash-separated group path.
+func NormalizeGroupPath(group string) (string, error) {
+	group = strings.TrimSpace(group)
+	if group == "" {
+		return "", nil
+	}
+	parts := strings.Split(group, "/")
+	if len(parts) > MaxGroupDepth {
+		return "", fmt.Errorf("groups can be at most %d levels deep", MaxGroupDepth)
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+		if parts[i] == "" {
+			return "", fmt.Errorf("group levels cannot be empty")
+		}
+	}
+	return strings.Join(parts, "/"), nil
+}
+
+// JoinLabelPath composes a label field value from group + leaf name.
+// An empty leaf with a group yields a trailing slash (useful when adding into a group).
+func JoinLabelPath(group, label string) string {
+	group = strings.TrimSpace(group)
+	label = strings.TrimSpace(label)
+	if group == "" {
+		return label
+	}
+	if label == "" {
+		return group + "/"
+	}
+	return group + "/" + label
+}
+
+// SplitLabelPath parses a label field path into group and leaf name.
+// The last segment is the label; everything before is the group.
+func SplitLabelPath(raw string) (group, label string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", nil
+	}
+	if strings.HasSuffix(raw, "/") {
+		return "", "", fmt.Errorf("label required after /")
+	}
+	parts := strings.Split(raw, "/")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+		if parts[i] == "" {
+			return "", "", fmt.Errorf("group levels cannot be empty")
+		}
+	}
+	if len(parts) == 1 {
+		return "", parts[0], nil
+	}
+	label = parts[len(parts)-1]
+	group, err = NormalizeGroupPath(strings.Join(parts[:len(parts)-1], "/"))
+	if err != nil {
+		return "", "", err
+	}
+	return group, label, nil
+}
+
+// LabelLeaf returns the display name portion of a label path (after the last /).
+func LabelLeaf(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if i := strings.LastIndex(raw, "/"); i >= 0 {
+		return strings.TrimSpace(raw[i+1:])
+	}
+	return raw
+}
+
+// LabelGroup returns the group portion of a label path (before the last /).
+func LabelGroup(raw string) string {
+	raw = strings.TrimSpace(raw)
+	i := strings.LastIndex(raw, "/")
+	if i < 0 {
+		return ""
+	}
+	group, err := NormalizeGroupPath(raw[:i])
+	if err != nil {
+		return strings.TrimSpace(raw[:i])
+	}
+	return group
+}

--- a/internal/metadata/label_path_test.go
+++ b/internal/metadata/label_path_test.go
@@ -1,0 +1,69 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitLabelPath(t *testing.T) {
+	tests := []struct {
+		raw     string
+		group   string
+		label   string
+		wantErr string
+	}{
+		{raw: "", group: "", label: ""},
+		{raw: "web", group: "", label: "web"},
+		{raw: "  web  ", group: "", label: "web"},
+		{raw: "abc/test", group: "abc", label: "test"},
+		{raw: "Work/Production/web", group: "Work/Production", label: "web"},
+		{raw: " one / two / three ", group: "one/two", label: "three"},
+		{raw: "one/two/three/four/five/leaf", group: "one/two/three/four/five", label: "leaf"},
+		{raw: "abc/", wantErr: "label required after /"},
+		{raw: "/web", wantErr: "group levels cannot be empty"},
+		{raw: "a//b", wantErr: "group levels cannot be empty"},
+		{raw: "one/two/three/four/five/six/leaf", wantErr: "at most 5 levels"},
+	}
+	for _, test := range tests {
+		group, label, err := SplitLabelPath(test.raw)
+		if test.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("SplitLabelPath(%q) err = %v, want containing %q", test.raw, err, test.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("SplitLabelPath(%q) unexpected err: %v", test.raw, err)
+		}
+		if group != test.group || label != test.label {
+			t.Fatalf("SplitLabelPath(%q) = (%q, %q), want (%q, %q)", test.raw, group, label, test.group, test.label)
+		}
+	}
+}
+
+func TestJoinAndLeafHelpers(t *testing.T) {
+	if got := JoinLabelPath("Work/Production", "web"); got != "Work/Production/web" {
+		t.Fatalf("JoinLabelPath = %q", got)
+	}
+	if got := JoinLabelPath("Work/Production", ""); got != "Work/Production/" {
+		t.Fatalf("JoinLabelPath trailing = %q", got)
+	}
+	if got := JoinLabelPath("", "web"); got != "web" {
+		t.Fatalf("JoinLabelPath leaf only = %q", got)
+	}
+	if got := LabelLeaf("Work/Production/web"); got != "web" {
+		t.Fatalf("LabelLeaf = %q", got)
+	}
+	if got := LabelLeaf("Work/Production/"); got != "" {
+		t.Fatalf("LabelLeaf empty leaf = %q", got)
+	}
+	if got := LabelGroup("Work/Production/web"); got != "Work/Production" {
+		t.Fatalf("LabelGroup = %q", got)
+	}
+	if got := LabelGroup("Work/Production/"); got != "Work/Production" {
+		t.Fatalf("LabelGroup trailing = %q", got)
+	}
+	if got := LabelGroup("web"); got != "" {
+		t.Fatalf("LabelGroup plain = %q", got)
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -461,6 +461,61 @@ func TestSyncedProviderRootStaysSeparateFromCompactedChildren(t *testing.T) {
 	}
 }
 
+func TestLabelPathSetsGroupAndLeaf(t *testing.T) {
+	m := testApp(t)
+	m.openEditHostForm()
+	for i := range m.form.fields {
+		if m.form.fields[i].label == "Label" {
+			m.form.fields[i].value = "abc/test"
+		}
+	}
+	m.submitForm()
+	if m.form != nil || m.statusError {
+		t.Fatalf("save failed: %q", m.status)
+	}
+	meta := m.metadata.Host("alpha")
+	if meta.Group != "abc" || meta.Label != "test" {
+		t.Fatalf("saved metadata = %+v", meta)
+	}
+}
+
+func TestLabelPathDisplayShowsLeafWhenInactive(t *testing.T) {
+	m := testApp(t)
+	if err := m.metadata.SetHost("alpha", metadata.Host{Label: "test", Group: "abc"}); err != nil {
+		t.Fatal(err)
+	}
+	for i, row := range m.hostRows() {
+		if !row.header && row.host.Alias == "alpha" {
+			m.cursor = i
+			break
+		}
+	}
+	m.openEditHostForm()
+	if m.form == nil {
+		t.Fatal("edit form did not open")
+	}
+	if got := formFieldByLabel(m, "Label").value; got != "abc/test" {
+		t.Fatalf("composed label path = %q", got)
+	}
+	m.form.hubIndex = 1
+	m.focusHostHubItem()
+	inactive := m.renderForm(m.styles())
+	if !strings.Contains(inactive, "Label  test") {
+		t.Fatalf("inactive label should show leaf only:\n%s", inactive)
+	}
+	if strings.Contains(inactive, "Label  abc/test") {
+		t.Fatalf("inactive label should not show full path:\n%s", inactive)
+	}
+	m.form.hubIndex = 0
+	m.focusHostHubItem()
+	m.form.input.SetValue("abc/test")
+	m.form.input.SetCursor(len([]rune("abc/test")))
+	focused := m.renderForm(m.styles())
+	if !strings.Contains(focused, "abc") || !strings.Contains(focused, "test") {
+		t.Fatalf("focused label should show full path:\n%s", focused)
+	}
+}
+
 func TestAddHostFormPrefillsGroupFromSelection(t *testing.T) {
 	m := testApp(t)
 	if err := m.metadata.SetHost("alpha", metadata.Host{Group: "Work/Production"}); err != nil {
@@ -474,8 +529,8 @@ func TestAddHostFormPrefillsGroupFromSelection(t *testing.T) {
 		}
 	}
 	m.openAddHostForm()
-	if got := formFieldByLabel(m, "Group").value; got != "Work/Production" {
-		t.Fatalf("group prefill = %q", got)
+	if got := formFieldByLabel(m, "Label").value; got != "Work/Production/" {
+		t.Fatalf("label path prefill = %q", got)
 	}
 	summary := m.hostFormSummary(formSectionMetadata)
 	if !strings.Contains(summary, "Work/Production") {
@@ -487,8 +542,8 @@ func TestGroupPathsAreNormalizedAndLimitedToFiveLevels(t *testing.T) {
 	m := testApp(t)
 	m.openEditHostForm()
 	for i := range m.form.fields {
-		if m.form.fields[i].label == "Group" {
-			m.form.fields[i].value = "one/two/three/four/five/six"
+		if m.form.fields[i].label == "Label" {
+			m.form.fields[i].value = "one/two/three/four/five/six/leaf"
 		}
 	}
 	m.submitForm()
@@ -501,8 +556,8 @@ func TestGroupPathsAreNormalizedAndLimitedToFiveLevels(t *testing.T) {
 
 	m.status, m.statusError = "", false
 	for i := range m.form.fields {
-		if m.form.fields[i].label == "Group" {
-			m.form.fields[i].value = " one / two / three / four / five "
+		if m.form.fields[i].label == "Label" {
+			m.form.fields[i].value = " one / two / three / four / five / leaf "
 		}
 	}
 	m.submitForm()
@@ -511,6 +566,9 @@ func TestGroupPathsAreNormalizedAndLimitedToFiveLevels(t *testing.T) {
 	}
 	if got := m.metadata.Host("alpha").Group; got != "one/two/three/four/five" {
 		t.Fatalf("normalized group = %q", got)
+	}
+	if got := m.metadata.Host("alpha").Label; got != "leaf" {
+		t.Fatalf("leaf label = %q", got)
 	}
 }
 
@@ -551,7 +609,7 @@ func TestExternalHostEditOnlyOffersMetadataAndIsFullyRevealed(t *testing.T) {
 	}
 	enterHostFormSection(t, m, formSectionMetadata)
 	rendered = m.renderForm(m.styles())
-	if !strings.Contains(rendered, "Group") || !strings.Contains(rendered, "Tags") {
+	if strings.Contains(rendered, "Group") || !strings.Contains(rendered, "Tags") {
 		t.Fatalf("metadata section was not opened:\n%s", rendered)
 	}
 	footer := m.renderFooter(m.styles())
@@ -594,21 +652,21 @@ func TestEditFormUsesArrowsToMoveAndEnterToSave(t *testing.T) {
 	m := testApp(t)
 	m.openEditHostForm()
 	enterHostFormSection(t, m, formSectionMetadata)
-	if m.form == nil || m.form.fields[m.form.index].label != "Group" {
-		t.Fatal("metadata section did not open on the group field")
+	if m.form == nil || m.form.fields[m.form.index].label != "Tags" {
+		t.Fatal("metadata section did not open on the tags field")
 	}
-	m.form.input.SetValue("operations")
+	m.form.input.SetValue("api")
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
 	m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
-	if m.form == nil || m.form.fields[m.form.index].label != "Group" {
-		t.Fatal("Up did not return to the group field")
+	if m.form == nil || m.form.fields[m.form.index].label != "Tags" {
+		t.Fatal("Up did not return to the tags field")
 	}
 	m.updateForm(ctrlEnter())
 	if m.form != nil {
 		t.Fatal("Ctrl+Enter did not save and close the edit form")
 	}
-	if got := m.metadata.Host("alpha").Group; got != "operations" {
-		t.Fatalf("saved group = %q", got)
+	if got := m.metadata.Host("alpha").Tags; len(got) != 1 || got[0] != "api" {
+		t.Fatalf("saved tags = %v", got)
 	}
 }
 
@@ -855,7 +913,7 @@ func TestHostFormExplainsOptionalConnectionFields(t *testing.T) {
 	m.openAddHostForm()
 
 	initial := m.renderForm(m.styles())
-	if !strings.Contains(initial, "Display name shown in Bast") {
+	if !strings.Contains(initial, "use / for groups") {
 		t.Fatalf("label description is missing:\n%s", initial)
 	}
 

--- a/internal/ui/forms.go
+++ b/internal/ui/forms.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	descHostLabel          = "Required - Display name shown in Bast"
+	descHostLabel          = "Display name; use / for groups, up to 5 levels"
 	descHostHostname       = "Required - Server hostname or IP address"
 	descHostUser           = "Optional - Remote username; blank uses SSH default"
 	descHostPort           = "Optional - Port number; blank defaults to 22"
@@ -30,7 +30,6 @@ const (
 	descHostCompression    = "Optional - Enable SSH compression"
 	descHostSetEnv         = "Optional - SetEnv pairs like FOO=bar, separated by ;"
 	descHostSSHFlags       = "Optional - Any other OpenSSH options, separated by ;"
-	descHostGroup          = "Optional - Use / for subgroups, up to 5 levels"
 	descHostTags           = "Optional - Comma-separated tags included in search"
 	descHostEnvironment    = "Optional - Environment name like production or staging"
 	descHostColor          = "Optional - Hex colour for the host label"
@@ -237,10 +236,12 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 	}
 	switch f.action {
 	case "host_add", "host_edit":
-		label := strings.TrimSpace(values["Label"])
-		group, groupErr := normalizeGroupPath(values["Group"])
-		if groupErr != nil {
-			return m.formError(groupErr.Error())
+		group, label, pathErr := metadata.SplitLabelPath(values["Label"])
+		if pathErr != nil {
+			return m.formError(pathErr.Error())
+		}
+		if strings.TrimSpace(label) == "" {
+			return m.formError("label is required")
 		}
 		groupCreated := group != "" && !m.groupExists(group)
 		adv := advancedSettingsFromForm(values)
@@ -304,12 +305,12 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 	case "metadata_edit":
 		alias := values["Alias"]
 		old := m.metadata.Host(alias)
-		group, err := normalizeGroupPath(values["Group"])
+		group, label, err := metadata.SplitLabelPath(values["Label"])
 		if err != nil {
 			return m.formError(err.Error())
 		}
 		groupCreated := group != "" && !m.groupExists(group)
-		old.Label, old.Group, old.Tags, old.Environment, old.Color, old.Notes = values["Label"], group, splitCSV(values["Tags"]), values["Environment"], values["Color"], values["Notes"]
+		old.Label, old.Group, old.Tags, old.Environment, old.Color, old.Notes = label, group, splitCSV(values["Tags"]), values["Environment"], values["Color"], values["Notes"]
 		if old.Label == alias {
 			old.Label = ""
 		}
@@ -434,7 +435,9 @@ func (m *App) formError(message string) (tea.Model, tea.Cmd) {
 
 func (m *App) openAddHostForm() {
 	group := m.defaultAddGroup()
-	m.openHostForm("Add host", "host_add", hostFormFields(m, metadataHostValues{group: group}, hostConnectionValues{includeConnection: true}, nil))
+	m.openHostForm("Add host", "host_add", hostFormFields(m, metadataHostValues{
+		label: metadata.JoinLabelPath(group, ""),
+	}, hostConnectionValues{includeConnection: true}, nil))
 }
 
 func (m *App) openEditGroupForm() {
@@ -462,11 +465,12 @@ func (m *App) openEditHostForm() {
 		return
 	}
 	meta := m.metadata.Host(host.Alias)
+	labelPath := metadata.JoinLabelPath(meta.Group, m.hostLabel(host))
 	if !host.Managed {
 		m.openHostForm("Edit metadata — "+m.hostLabel(host), "metadata_edit", hostFormFields(m, metadataHostValues{
-			label: m.hostLabel(host), group: meta.Group, tags: strings.Join(meta.Tags, ", "),
+			label: labelPath, tags: strings.Join(meta.Tags, ", "),
 			environment: meta.Environment, color: meta.Color, notes: meta.Notes,
-			labelDesc: "Optional - Display name; SSH alias stays " + host.Alias,
+			labelDesc: "Optional - Display name; use / for groups; SSH alias stays " + host.Alias,
 		}, hostConnectionValues{}, []field{{label: "Alias", value: host.Alias, hidden: true}}))
 		return
 	}
@@ -478,7 +482,7 @@ func (m *App) openEditHostForm() {
 	extras, _ := m.config.ManagedExtras(host.ManagedID)
 	adv := sshconfig.ParseAdvanced(extras, emptyIfNone(host.Resolved.ProxyJump))
 	m.openHostForm("Edit host — "+m.hostLabel(host), "host_edit", hostFormFields(m, metadataHostValues{
-		label: m.hostLabel(host), group: meta.Group, tags: strings.Join(meta.Tags, ", "),
+		label: labelPath, tags: strings.Join(meta.Tags, ", "),
 		environment: meta.Environment, color: meta.Color, notes: meta.Notes,
 	}, hostConnectionValues{
 		includeConnection: true,

--- a/internal/ui/host_form.go
+++ b/internal/ui/host_form.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"bast/internal/metadata"
 	"bast/internal/sshconfig"
 )
 
@@ -103,8 +104,10 @@ func (m *App) hostFormSummary(section string) string {
 		return m.hostAdvancedSummary()
 	case formSectionMetadata:
 		parts := []string{}
-		if group := fieldDisplay(f, "Group"); group != "" && group != "—" {
-			parts = append(parts, group)
+		if labelField := f.fieldByLabel("Label"); labelField != nil {
+			if group := metadata.LabelGroup(labelField.value); group != "" {
+				parts = append(parts, group)
+			}
 		}
 		if env := fieldDisplay(f, "Environment"); env != "" && env != "—" {
 			parts = append(parts, env)
@@ -540,13 +543,63 @@ func (m *App) renderHostHubBasicsRow(b *strings.Builder, s styleSet, hub hostHub
 		if item.description != "" {
 			b.WriteString("    " + s.muted.Render(truncate(item.description, max(20, m.terminalWidth()-8))) + "\n")
 		}
-		b.WriteString("    " + f.input.View() + "\n")
+		if hub.id == "label" {
+			b.WriteString("    " + m.renderLabelPathInput(s) + "\n")
+		} else {
+			b.WriteString("    " + f.input.View() + "\n")
+		}
 		return
+	}
+	if hub.id == "label" {
+		value = metadata.LabelLeaf(value)
 	}
 	if value == "" {
 		value = "—"
 	}
 	b.WriteString("  " + s.muted.Render("  "+item.label+"  "+value) + "\n")
+}
+
+// renderLabelPathInput shows the full label path while editing. The group
+// prefix is muted until the cursor moves into it.
+func (m *App) renderLabelPathInput(s styleSet) string {
+	f := m.form
+	value := f.input.Value()
+	if value == "" {
+		return f.input.View()
+	}
+	runes := []rune(value)
+	pos := f.input.Position()
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(runes) {
+		pos = len(runes)
+	}
+	lastSlash := -1
+	for i, r := range runes {
+		if r == '/' {
+			lastSlash = i
+		}
+	}
+	mutePrefix := lastSlash >= 0 && pos > lastSlash
+
+	var out strings.Builder
+	for i, r := range runes {
+		style := s.value
+		if mutePrefix && i <= lastSlash {
+			style = s.muted
+		}
+		char := string(r)
+		if i == pos {
+			out.WriteString(lipgloss.NewStyle().Reverse(true).Render(char))
+			continue
+		}
+		out.WriteString(style.Render(char))
+	}
+	if pos >= len(runes) {
+		out.WriteString(lipgloss.NewStyle().Reverse(true).Render(" "))
+	}
+	return out.String()
 }
 
 func (m *App) renderHostHubMenuRow(b *strings.Builder, s styleSet, hub hostHubItem) {
@@ -682,7 +735,7 @@ func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, 
 		labelDesc = descHostLabel
 	}
 	fields = append(fields,
-		field{label: "Label", section: formSectionBasics, description: labelDesc, value: meta.label, placeholder: "Production web"},
+		field{label: "Label", section: formSectionBasics, description: labelDesc, value: meta.label, placeholder: "Work/api"},
 	)
 	if conn.includeConnection {
 		fields = append(fields,
@@ -695,7 +748,6 @@ func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, 
 		fields = append(fields, advancedFormFields(m, conn.advanced)...)
 	}
 	fields = append(fields,
-		field{label: "Group", section: formSectionMetadata, description: descHostGroup, value: meta.group, placeholder: "Work/Production", optional: true},
 		field{label: "Tags", section: formSectionMetadata, description: descHostTags, value: meta.tags, placeholder: "web, production", optional: true},
 		field{label: "Environment", section: formSectionMetadata, description: descHostEnvironment, value: meta.environment, placeholder: "production", optional: true},
 		field{label: "Color", section: formSectionMetadata, description: descHostColor, value: meta.color, placeholder: "#7C3AED", optional: true},
@@ -705,7 +757,7 @@ func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, 
 }
 
 type metadataHostValues struct {
-	label, group, tags, environment, color, notes, labelDesc string
+	label, tags, environment, color, notes, labelDesc string
 }
 
 type hostConnectionValues struct {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -17,8 +17,6 @@ import (
 
 const noticeDuration = 4 * time.Second
 
-const maxGroupDepth = 5
-
 const mobileBreakpoint = 60
 
 type panelLayout struct {
@@ -281,21 +279,7 @@ func (m *App) appendGroupRows(rows []hostRow, group *hostGroup, depth int) []hos
 }
 
 func normalizeGroupPath(group string) (string, error) {
-	group = strings.TrimSpace(group)
-	if group == "" {
-		return "", nil
-	}
-	parts := strings.Split(group, "/")
-	if len(parts) > maxGroupDepth {
-		return "", fmt.Errorf("groups can be at most %d levels deep", maxGroupDepth)
-	}
-	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
-		if parts[i] == "" {
-			return "", fmt.Errorf("group levels cannot be empty")
-		}
-	}
-	return strings.Join(parts, "/"), nil
+	return metadata.NormalizeGroupPath(group)
 }
 
 func groupPathParts(group string) []string {


### PR DESCRIPTION
closes #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added hierarchical label paths for hosts (for example, `Work/Production/web`) to derive group and leaf automatically.
  - UI and CLI now consistently interpret label paths, including when editing existing hosts (with explicit group overriding as appropriate).
  - Display shows the full path while editing, and the leaf-focused view when not focused.
- **Documentation**
  - Updated README and CLI help text to clarify label-path behavior and group overrides/clearing.
- **Tests**
  - Added CLI and UI test coverage for label-path splitting, normalization limits, and display persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->