### PR TITLE
feat: import hosts from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Bast is a terminal UI for the SSH config and keys you already have. It reads `~/
 
 You can generate and manage keys, push public keys to servers, and do most of it from the CLI if you'd rather skip the TUI.
 
+On startup, Bast checks standard zsh, bash, and fish history files in the background for SSH destinations that are not already configured. Suggestions appear below your hosts under `(Suggested)`. Press Enter to add one, `e` to review it first, or `x` to dismiss it. Bast stores normalized connection fields and scan checkpoints, not the original history command.
+
 Groups can nest up to five levels. Set them in the label with a path (`Work/Production/web` puts the host in `Work/Production` and names it `web`). In the TUI, the inactive Label row shows just the name; focusing it reveals the full path, with the group prefix muted until the cursor moves into it. `--group` remains available on the CLI. Bast stores presentation metadata in `~/.config/bast`. OpenSSH stays the source of truth for hosts and keys.
 
 ## Requirements
@@ -157,7 +159,7 @@ Groups can nest up to five levels. Set them in the label with a path (`Work/Prod
 
 `1` hosts · `2` keys · `3` sync · arrows or `j`/`k` to move · `g`/`G` top/bottom · `/` search · `r` reload · `v` version info
 
-**Hosts:** Enter connect · `a` add · `e` edit · `d` delete · `f` favorite · `h` hide · `.` show hidden · Space collapse/expand group · `[` collapse all · `]` expand all · `s` sort · `K` drop known-host entry
+**Hosts:** Enter connect/add suggestion · `a` add · `e` edit/review suggestion · `x` dismiss suggestion · `d` delete · `f` favorite · `h` hide · `.` show hidden · Space collapse/expand group · `[` collapse all · `]` expand all · `s` sort · `K` drop known-host entry
 
 **Keys:** `a` generate · `i` import · `e` edit comment · `d` delete · `u` push to server · `x` export · `p` passphrase · `c` copy public key
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Bast is a terminal UI for the SSH config and keys you already have. It reads `~/
 
 You can generate and manage keys, push public keys to servers, and do most of it from the CLI if you'd rather skip the TUI.
 
-On startup, Bast checks standard zsh, bash, and fish history files in the background for SSH destinations that are not already configured. Suggestions appear below your hosts under `(Suggested)`. Press Enter to add one, `e` to review it first, or `x` to dismiss it. Bast stores normalized connection fields and scan checkpoints, not the original history command.
+On startup, Bast checks standard zsh (`~/.zsh_history`, `~/.zhistory`, `$HISTFILE`, and `$ZDOTDIR`), bash, and fish history files in the background for SSH destinations that are not already configured. Suggestions appear below your hosts under `(Suggested)`. Press Enter to add one, `e` to review it first, or `x` to dismiss it. Bast stores normalized connection fields and scan checkpoints, not the original history command.
 
 Groups can nest up to five levels. Set them in the label with a path (`Work/Production/web` puts the host in `Work/Production` and names it `web`). In the TUI, the inactive Label row shows just the name; focusing it reveals the full path, with the group prefix muted until the cursor moves into it. `--group` remains available on the CLI. Bast stores presentation metadata in `~/.config/bast`. OpenSSH stays the source of truth for hosts and keys.
 

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,728 @@
+package history
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"bast/internal/metadata"
+	"bast/internal/sshconfig"
+)
+
+const (
+	anchorCount  = 8
+	anchorBytes  = 4096
+	maxRecordLen = 1024 * 1024
+)
+
+type record struct {
+	command string
+	seenAt  int64
+}
+
+// Scan reads new records from every standard shell history source. It returns
+// an updated snapshot; callers decide when that snapshot is durably stored.
+func Scan(home string, getenv func(string) string, previous metadata.HistoryImport, hosts []sshconfig.Host) (metadata.HistoryImport, []error) {
+	next := metadata.HistoryImport{
+		Sources: make(map[string]metadata.HistorySource, len(previous.Sources)),
+		Pending: append([]metadata.HistorySuggestion(nil), previous.Pending...),
+	}
+	for path, source := range previous.Sources {
+		source.Anchors = append([]string(nil), source.Anchors...)
+		next.Sources[path] = source
+	}
+	pending := make(map[string]metadata.HistorySuggestion, len(next.Pending))
+	for _, suggestion := range next.Pending {
+		pending[suggestion.ID] = suggestion
+	}
+
+	aliases, endpoints := existingHosts(hosts)
+	var scanErrors []error
+	for _, path := range sourcePaths(home, getenv) {
+		info, err := os.Stat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			scanErrors = append(scanErrors, fmt.Errorf("read %s history: %w", shellName(path), err))
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		checkpoint := next.Sources[path]
+		updated, suggestions, err := scanSource(path, info, checkpoint)
+		if err != nil {
+			scanErrors = append(scanErrors, fmt.Errorf("read %s history: %w", shellName(path), err))
+			continue
+		}
+		next.Sources[path] = updated
+		for _, suggestion := range suggestions {
+			if aliases[strings.ToLower(suggestion.Target)] || endpoints[endpointKey(suggestion.User, suggestion.HostName, suggestion.Port)] {
+				continue
+			}
+			if current, ok := pending[suggestion.ID]; !ok || suggestion.SeenAt >= current.SeenAt {
+				pending[suggestion.ID] = suggestion
+			}
+		}
+	}
+
+	next.Pending = next.Pending[:0]
+	for _, suggestion := range pending {
+		if aliases[strings.ToLower(suggestion.Target)] || endpoints[endpointKey(suggestion.User, suggestion.HostName, suggestion.Port)] {
+			continue
+		}
+		next.Pending = append(next.Pending, suggestion)
+	}
+	sort.Slice(next.Pending, func(i, j int) bool {
+		if next.Pending[i].SeenAt != next.Pending[j].SeenAt {
+			return next.Pending[i].SeenAt > next.Pending[j].SeenAt
+		}
+		return next.Pending[i].ID < next.Pending[j].ID
+	})
+	assignAliases(next.Pending, aliases)
+	return next, scanErrors
+}
+
+func sourcePaths(home string, getenv func(string) string) []string {
+	paths := []string{
+		filepath.Join(home, ".zsh_history"),
+		filepath.Join(home, ".bash_history"),
+	}
+	if histfile := strings.TrimSpace(getenv("HISTFILE")); histfile != "" {
+		paths = append(paths, expandHome(histfile, home))
+	}
+	if zdotdir := strings.TrimSpace(getenv("ZDOTDIR")); zdotdir != "" {
+		paths = append(paths, filepath.Join(expandHome(zdotdir, home), ".zsh_history"))
+	}
+	dataHome := strings.TrimSpace(getenv("XDG_DATA_HOME"))
+	if dataHome == "" {
+		dataHome = filepath.Join(home, ".local", "share")
+	} else {
+		dataHome = expandHome(dataHome, home)
+	}
+	fishSession := strings.TrimSpace(getenv("fish_history"))
+	if fishSession == "" || fishSession == "default" {
+		fishSession = "fish"
+	}
+	if fishSession != "" && !strings.ContainsAny(fishSession, `/\\`) {
+		paths = append(paths, filepath.Join(dataHome, "fish", fishSession+"_history"))
+	}
+
+	seen := map[string]bool{}
+	unique := paths[:0]
+	for _, path := range paths {
+		path = filepath.Clean(path)
+		if !seen[path] {
+			seen[path] = true
+			unique = append(unique, path)
+		}
+	}
+	return unique
+}
+
+func expandHome(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return path
+}
+
+func scanSource(path string, info os.FileInfo, checkpoint metadata.HistorySource) (metadata.HistorySource, []metadata.HistorySuggestion, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return checkpoint, nil, err
+	}
+	defer file.Close()
+	size := info.Size()
+	format, err := detectFormat(file, path, size)
+	if err != nil {
+		return checkpoint, nil, err
+	}
+
+	start := int64(0)
+	skipRecords := int64(0)
+	anchorsComplete := false
+	emit := checkpoint.Offset == 0 && checkpoint.TailHash == "" && len(checkpoint.Anchors) == 0
+	anchors := []string(nil)
+	if !emit && checkpoint.Offset <= size && checkpoint.TailHash != "" {
+		valid, hashErr := matchesTail(file, checkpoint.Offset, checkpoint.TailHash)
+		if hashErr != nil {
+			return checkpoint, nil, hashErr
+		}
+		if valid {
+			start, emit, anchors = checkpoint.Offset, true, append([]string(nil), checkpoint.Anchors...)
+		}
+	}
+
+	if !emit && len(checkpoint.Anchors) > 0 {
+		matchAfter, lastAnchors, walkErr := locateAnchors(io.NewSectionReader(file, 0, size), format, checkpoint.Anchors)
+		if walkErr != nil {
+			return checkpoint, nil, walkErr
+		}
+		anchors = lastAnchors
+		anchorsComplete = true
+		if matchAfter >= 0 {
+			start = 0
+			skipRecords = matchAfter
+			emit = true
+		}
+	}
+
+	var suggestions []metadata.HistorySuggestion
+	var newAnchors []string
+	if emit {
+		reader := io.NewSectionReader(file, start, size-start)
+		index := int64(0)
+		err = walkRecords(reader, format, func(item record) error {
+			index++
+			if index <= skipRecords {
+				return nil
+			}
+			newAnchors = appendAnchor(newAnchors, recordHash(item.command))
+			suggestion, ok := parseSSH(item.command)
+			if !ok {
+				return nil
+			}
+			suggestion.Source = format
+			if item.seenAt != 0 {
+				suggestion.SeenAt = item.seenAt * 1_000_000_000
+			} else {
+				suggestion.SeenAt = info.ModTime().UnixNano() + index
+			}
+			suggestions = append(suggestions, suggestion)
+			return nil
+		})
+		if err != nil {
+			return checkpoint, nil, err
+		}
+		if !anchorsComplete {
+			anchors = appendAnchors(anchors, newAnchors)
+		}
+	}
+	if len(anchors) == 0 {
+		var walkErr error
+		anchors, walkErr = lastRecordAnchors(io.NewSectionReader(file, 0, size), format)
+		if walkErr != nil {
+			return checkpoint, nil, walkErr
+		}
+	}
+	tailHash, err := tailHash(file, size)
+	if err != nil {
+		return checkpoint, nil, err
+	}
+	return metadata.HistorySource{Offset: size, TailHash: tailHash, Anchors: anchors}, suggestions, nil
+}
+
+func detectFormat(file *os.File, path string, size int64) (string, error) {
+	name := strings.ToLower(filepath.Base(path))
+	switch {
+	case strings.Contains(name, "zsh"):
+		return "zsh", nil
+	case strings.Contains(name, "bash"):
+		return "bash", nil
+	case strings.HasSuffix(name, "_history") && strings.Contains(filepath.ToSlash(path), "/fish/"):
+		return "fish", nil
+	}
+	peek := make([]byte, min(int64(8192), size))
+	if _, err := file.ReadAt(peek, 0); err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	text := string(peek)
+	if strings.Contains(text, "\n- cmd: ") || strings.HasPrefix(text, "- cmd: ") {
+		return "fish", nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(text), ": ") {
+		return "zsh", nil
+	}
+	return "bash", nil
+}
+
+func shellName(path string) string {
+	path = strings.ToLower(filepath.ToSlash(path))
+	switch {
+	case strings.Contains(path, "fish"):
+		return "fish"
+	case strings.Contains(path, "bash"):
+		return "bash"
+	default:
+		return "zsh"
+	}
+}
+
+func matchesTail(file *os.File, offset int64, want string) (bool, error) {
+	got, err := tailHash(file, offset)
+	return got == want, err
+}
+
+func tailHash(file *os.File, offset int64) (string, error) {
+	start := max(int64(0), offset-anchorBytes)
+	data := make([]byte, offset-start)
+	if len(data) > 0 {
+		if _, err := file.ReadAt(data, start); err != nil && !errors.Is(err, io.EOF) {
+			return "", err
+		}
+	}
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func locateAnchors(reader io.Reader, format string, want []string) (int64, []string, error) {
+	window := make([]string, 0, len(want))
+	lastMatch := int64(-1)
+	var records int64
+	last := []string(nil)
+	err := walkRecords(reader, format, func(item record) error {
+		records++
+		hash := recordHash(item.command)
+		last = appendAnchor(last, hash)
+		window = append(window, hash)
+		if len(window) > len(want) {
+			window = window[1:]
+		}
+		if len(window) == len(want) && equalStrings(window, want) {
+			lastMatch = records
+		}
+		return nil
+	})
+	return lastMatch, last, err
+}
+
+func lastRecordAnchors(reader io.Reader, format string) ([]string, error) {
+	var anchors []string
+	err := walkRecords(reader, format, func(item record) error {
+		anchors = appendAnchor(anchors, recordHash(item.command))
+		return nil
+	})
+	return anchors, err
+}
+
+func appendAnchor(anchors []string, hash string) []string {
+	anchors = append(anchors, hash)
+	if len(anchors) > anchorCount {
+		anchors = anchors[len(anchors)-anchorCount:]
+	}
+	return anchors
+}
+
+func appendAnchors(current, added []string) []string {
+	for _, hash := range added {
+		current = appendAnchor(current, hash)
+	}
+	return current
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func recordHash(command string) string {
+	hash := sha256.Sum256([]byte(command))
+	return hex.EncodeToString(hash[:])
+}
+
+func walkRecords(reader io.Reader, format string, visit func(record) error) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), maxRecordLen)
+	call := func(command string, seenAt int64) error {
+		command = strings.TrimSpace(command)
+		if command == "" {
+			return nil
+		}
+		return visit(record{command: command, seenAt: seenAt})
+	}
+
+	switch format {
+	case "fish":
+		command := ""
+		var seenAt int64
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "- cmd: ") {
+				if err := call(command, seenAt); err != nil {
+					return err
+				}
+				command, seenAt = unescapeFish(strings.TrimPrefix(line, "- cmd: ")), 0
+			} else if command != "" && strings.HasPrefix(line, "  when: ") {
+				seenAt, _ = strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, "  when: ")), 10, 64)
+			}
+		}
+		if err := call(command, seenAt); err != nil {
+			return err
+		}
+	case "zsh":
+		for scanner.Scan() {
+			line := scanner.Text()
+			command, seenAt := parseZshRecord(line)
+			if err := call(command, seenAt); err != nil {
+				return err
+			}
+		}
+	default:
+		var command strings.Builder
+		var seenAt int64
+		timestamped := false
+		flush := func() error {
+			err := call(command.String(), seenAt)
+			command.Reset()
+			return err
+		}
+		for scanner.Scan() {
+			line := scanner.Text()
+			if timestamp, ok := bashTimestamp(line); ok {
+				if err := flush(); err != nil {
+					return err
+				}
+				seenAt, timestamped = timestamp, true
+				continue
+			}
+			if timestamped {
+				if command.Len() > 0 {
+					command.WriteByte('\n')
+				}
+				command.WriteString(line)
+			} else if err := call(line, 0); err != nil {
+				return err
+			}
+		}
+		if err := flush(); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func parseZshRecord(line string) (string, int64) {
+	if !strings.HasPrefix(line, ": ") {
+		return line, 0
+	}
+	rest := strings.TrimPrefix(line, ": ")
+	firstColon := strings.IndexByte(rest, ':')
+	semicolon := strings.IndexByte(rest, ';')
+	if firstColon < 1 || semicolon < firstColon {
+		return line, 0
+	}
+	timestamp, err := strconv.ParseInt(rest[:firstColon], 10, 64)
+	if err != nil {
+		return line, 0
+	}
+	return rest[semicolon+1:], timestamp
+}
+
+func bashTimestamp(line string) (int64, bool) {
+	if len(line) < 2 || line[0] != '#' {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(line[1:], 10, 64)
+	return value, err == nil
+}
+
+func unescapeFish(value string) string {
+	quoted := `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+	if unquoted, err := strconv.Unquote(quoted); err == nil {
+		return unquoted
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(value, `\n`, "\n"), `\\`, `\`)
+}
+
+func parseSSH(command string) (metadata.HistorySuggestion, bool) {
+	words, ok := shellWords(command)
+	if !ok || len(words) < 2 {
+		return metadata.HistorySuggestion{}, false
+	}
+	if words[0] == "command" || words[0] == "exec" {
+		words = words[1:]
+		if len(words) > 0 && words[0] == "--" {
+			words = words[1:]
+		}
+	}
+	if len(words) < 2 || filepath.Base(words[0]) != "ssh" {
+		return metadata.HistorySuggestion{}, false
+	}
+
+	var user, hostname, port, identityFile, proxyJump, target string
+	for i := 1; i < len(words); i++ {
+		word := words[i]
+		if word == "--" {
+			i++
+			if i >= len(words) {
+				return metadata.HistorySuggestion{}, false
+			}
+			target = words[i]
+			break
+		}
+		if !strings.HasPrefix(word, "-") || word == "-" {
+			target = word
+			break
+		}
+		name, value, attached := sshOption(word)
+		switch name {
+		case "l", "p", "i", "J", "o":
+			if !attached {
+				i++
+				if i >= len(words) {
+					return metadata.HistorySuggestion{}, false
+				}
+				value = words[i]
+			}
+			switch name {
+			case "l":
+				user = value
+			case "p":
+				port = value
+			case "i":
+				if safeIdentityPath(value) {
+					identityFile = value
+				}
+			case "J":
+				proxyJump = value
+			case "o":
+				key, optionValue := sshConfigOption(value)
+				switch strings.ToLower(key) {
+				case "hostname":
+					hostname = optionValue
+				case "user":
+					user = optionValue
+				case "port":
+					port = optionValue
+				case "identityfile":
+					if safeIdentityPath(optionValue) {
+						identityFile = optionValue
+					}
+				case "proxyjump":
+					proxyJump = optionValue
+				case "addressfamily", "batchmode", "compression", "connecttimeout", "forwardagent", "ipqos", "loglevel", "requesttty", "serveralivecountmax", "serveraliveinterval", "stricthostkeychecking", "userknownhostsfile", "localforward", "remoteforward", "dynamicforward":
+					// These affect a single invocation but not the imported endpoint.
+				default:
+					return metadata.HistorySuggestion{}, false
+				}
+			}
+		case "F":
+			return metadata.HistorySuggestion{}, false
+		case "B", "b", "c", "D", "E", "e", "I", "L", "m", "P", "R", "S", "W", "w":
+			if !attached {
+				i++
+				if i >= len(words) {
+					return metadata.HistorySuggestion{}, false
+				}
+			}
+		case "G", "O", "Q", "V":
+			return metadata.HistorySuggestion{}, false
+		case "4", "6", "A", "a", "C", "f", "g", "K", "k", "M", "N", "n", "q", "s", "T", "t", "v", "X", "x", "Y", "y":
+		default:
+			return metadata.HistorySuggestion{}, false
+		}
+	}
+	if target == "" || hasUnsafeShellChars(target) {
+		return metadata.HistorySuggestion{}, false
+	}
+	targetHost := target
+	if at := strings.LastIndex(target, "@"); at >= 0 {
+		if user == "" {
+			user = target[:at]
+		}
+		targetHost = target[at+1:]
+	}
+	targetHost = strings.TrimSuffix(strings.TrimPrefix(targetHost, "["), "]")
+	if hostname == "" {
+		hostname = targetHost
+	}
+	if hostname == "" || hasUnsafeShellChars(hostname) || hasUnsafeShellChars(user) || hasUnsafeShellChars(proxyJump) {
+		return metadata.HistorySuggestion{}, false
+	}
+	input := sshconfig.HostInput{Alias: baseAlias(user, hostname), HostName: hostname, User: user, Port: port, IdentityFile: identityFile, ProxyJump: proxyJump}
+	if err := sshconfig.Validate(input); err != nil {
+		return metadata.HistorySuggestion{}, false
+	}
+	id := endpointID(user, hostname, port)
+	return metadata.HistorySuggestion{
+		ID: id, Alias: input.Alias, Target: targetHost, HostName: hostname, User: user,
+		Port: port, IdentityFile: identityFile, ProxyJump: proxyJump,
+	}, true
+}
+
+func sshOption(word string) (name, value string, attached bool) {
+	trimmed := strings.TrimPrefix(word, "-")
+	if trimmed == "" {
+		return "", "", false
+	}
+	name = trimmed[:1]
+	if len(trimmed) > 1 {
+		return name, trimmed[1:], true
+	}
+	return name, "", false
+}
+
+func sshConfigOption(option string) (string, string) {
+	if key, value, ok := strings.Cut(option, "="); ok {
+		return strings.TrimSpace(key), strings.TrimSpace(value)
+	}
+	parts := strings.Fields(option)
+	if len(parts) >= 2 {
+		return parts[0], strings.Join(parts[1:], " ")
+	}
+	return option, ""
+}
+
+func safeIdentityPath(path string) bool {
+	if path == "" || strings.ContainsAny(path, "\r\n\x00`;|&<>") {
+		return false
+	}
+	if strings.Contains(path, "$") {
+		end := strings.IndexByte(path, '}')
+		if !strings.HasPrefix(path, "${") || end < 3 || strings.Contains(path[end+1:], "$") {
+			return false
+		}
+		for _, char := range path[2:end] {
+			if !unicode.IsLetter(char) && !unicode.IsDigit(char) && char != '_' {
+				return false
+			}
+		}
+	}
+	return filepath.IsAbs(path) || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, "${") || strings.HasPrefix(path, "%")
+}
+
+func hasUnsafeShellChars(value string) bool {
+	return strings.ContainsAny(value, "\r\n\x00`$;|&<>")
+}
+
+func shellWords(command string) ([]string, bool) {
+	var words []string
+	var word strings.Builder
+	quote := rune(0)
+	escaped := false
+	started := false
+	flush := func() {
+		if started {
+			words = append(words, word.String())
+			word.Reset()
+			started = false
+		}
+	}
+	for _, char := range command {
+		if escaped {
+			word.WriteRune(char)
+			started, escaped = true, false
+			continue
+		}
+		if quote != 0 {
+			if char == quote {
+				quote = 0
+			} else if char == '\\' && quote == '"' {
+				escaped = true
+			} else {
+				word.WriteRune(char)
+				started = true
+			}
+			continue
+		}
+		switch {
+		case char == '\\':
+			escaped, started = true, true
+		case char == '\'' || char == '"':
+			quote, started = char, true
+		case unicode.IsSpace(char):
+			flush()
+		case char == '#' && !started:
+			flush()
+			return words, true
+		case strings.ContainsRune(";|&", char):
+			flush()
+			return words, true
+		default:
+			word.WriteRune(char)
+			started = true
+		}
+	}
+	if quote != 0 || escaped {
+		return nil, false
+	}
+	flush()
+	return words, true
+}
+
+func endpointID(user, hostname, port string) string {
+	hash := sha256.Sum256([]byte(endpointKey(user, hostname, port)))
+	return hex.EncodeToString(hash[:])
+}
+
+func endpointKey(user, hostname, port string) string {
+	if port == "" {
+		port = "22"
+	}
+	return strings.ToLower(strings.TrimSpace(user)) + "\x00" + strings.ToLower(strings.TrimSpace(hostname)) + "\x00" + port
+}
+
+func existingHosts(hosts []sshconfig.Host) (map[string]bool, map[string]bool) {
+	aliases := make(map[string]bool, len(hosts))
+	endpoints := make(map[string]bool, len(hosts))
+	for _, host := range hosts {
+		aliases[strings.ToLower(host.Alias)] = true
+		hostname := host.Resolved.HostName
+		if hostname == "" {
+			hostname = host.Alias
+		}
+		endpoints[endpointKey(host.Resolved.User, hostname, host.Resolved.Port)] = true
+	}
+	return aliases, endpoints
+}
+
+func assignAliases(suggestions []metadata.HistorySuggestion, existing map[string]bool) {
+	used := make(map[string]bool, len(existing)+len(suggestions))
+	for alias := range existing {
+		used[alias] = true
+	}
+	for i := range suggestions {
+		base := baseAlias(suggestions[i].User, suggestions[i].HostName)
+		alias := base
+		for suffix := 2; used[strings.ToLower(alias)]; suffix++ {
+			alias = fmt.Sprintf("%s-%d", base, suffix)
+		}
+		suggestions[i].Alias = alias
+		used[strings.ToLower(alias)] = true
+	}
+}
+
+func baseAlias(user, hostname string) string {
+	value := strings.ToLower(hostname)
+	if user != "" {
+		value = strings.ToLower(user) + "-" + value
+	}
+	var alias strings.Builder
+	lastDash := false
+	for _, char := range value {
+		allowed := unicode.IsLetter(char) || unicode.IsDigit(char) || char == '.' || char == '_' || char == '-'
+		if allowed {
+			alias.WriteRune(char)
+			lastDash = char == '-'
+		} else if !lastDash {
+			alias.WriteByte('-')
+			lastDash = true
+		}
+	}
+	clean := strings.Trim(alias.String(), ".-_")
+	if clean == "" {
+		return "host"
+	}
+	return clean
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 const (
 	anchorCount  = 8
 	anchorBytes  = 4096
+	maxPending   = 200
 	maxRecordLen = 1024 * 1024
 )
 
@@ -89,6 +91,9 @@ func Scan(home string, getenv func(string) string, previous metadata.HistoryImpo
 		}
 		return next.Pending[i].ID < next.Pending[j].ID
 	})
+	if len(next.Pending) > maxPending {
+		next.Pending = next.Pending[:maxPending]
+	}
 	assignAliases(next.Pending, aliases)
 	return next, scanErrors
 }
@@ -116,7 +121,7 @@ func sourcePaths(home string, getenv func(string) string) []string {
 	if fishSession == "" || fishSession == "default" {
 		fishSession = "fish"
 	}
-	if fishSession != "" && !strings.ContainsAny(fishSession, `/\\`) {
+	if !strings.ContainsAny(fishSession, `/\`) {
 		paths = append(paths, filepath.Join(dataHome, "fish", fishSession+"_history"))
 	}
 
@@ -221,11 +226,11 @@ func scanSource(path string, info os.FileInfo, checkpoint metadata.HistorySource
 			return checkpoint, nil, walkErr
 		}
 	}
-	tailHash, err := tailHash(file, size)
+	tail, err := tailHash(file, size)
 	if err != nil {
 		return checkpoint, nil, err
 	}
-	return metadata.HistorySource{Offset: size, TailHash: tailHash, Anchors: anchors}, suggestions, nil
+	return metadata.HistorySource{Offset: size, TailHash: tail, Anchors: anchors}, suggestions, nil
 }
 
 func detectFormat(file *os.File, path string, size int64) (string, error) {
@@ -294,7 +299,7 @@ func locateAnchors(reader io.Reader, format string, want []string) (int64, []str
 		if len(window) > len(want) {
 			window = window[1:]
 		}
-		if len(window) == len(want) && equalStrings(window, want) {
+		if len(window) == len(want) && slices.Equal(window, want) {
 			lastMatch = records
 		}
 		return nil
@@ -326,26 +331,12 @@ func appendAnchors(current, added []string) []string {
 	return current
 }
 
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 func recordHash(command string) string {
 	hash := sha256.Sum256([]byte(command))
 	return hex.EncodeToString(hash[:])
 }
 
 func walkRecords(reader io.Reader, format string, visit func(record) error) error {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 64*1024), maxRecordLen)
 	call := func(command string, seenAt int64) error {
 		command = strings.TrimSpace(command)
 		if command == "" {
@@ -353,13 +344,49 @@ func walkRecords(reader io.Reader, format string, visit func(record) error) erro
 		}
 		return visit(record{command: command, seenAt: seenAt})
 	}
+	walkLines := func(handle func(line string, oversized bool) error) error {
+		buffered := bufio.NewReaderSize(reader, 64*1024)
+		var line strings.Builder
+		oversized := false
+		for {
+			fragment, more, err := buffered.ReadLine()
+			if errors.Is(err, io.EOF) && len(fragment) == 0 && line.Len() == 0 && !oversized {
+				return nil
+			}
+			if err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			if !oversized {
+				if line.Len()+len(fragment) > maxRecordLen {
+					line.Reset()
+					oversized = true
+				} else {
+					_, _ = line.Write(fragment)
+				}
+			}
+			if !more {
+				if err := handle(line.String(), oversized); err != nil {
+					return err
+				}
+				line.Reset()
+				oversized = false
+			}
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+		}
+	}
 
 	switch format {
 	case "fish":
 		command := ""
 		var seenAt int64
-		for scanner.Scan() {
-			line := scanner.Text()
+		if err := walkLines(func(line string, oversized bool) error {
+			if oversized {
+				err := call(command, seenAt)
+				command, seenAt = "", 0
+				return err
+			}
 			if strings.HasPrefix(line, "- cmd: ") {
 				if err := call(command, seenAt); err != nil {
 					return err
@@ -368,50 +395,79 @@ func walkRecords(reader io.Reader, format string, visit func(record) error) erro
 			} else if command != "" && strings.HasPrefix(line, "  when: ") {
 				seenAt, _ = strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(line, "  when: ")), 10, 64)
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
 		if err := call(command, seenAt); err != nil {
 			return err
 		}
 	case "zsh":
-		for scanner.Scan() {
-			line := scanner.Text()
-			command, seenAt := parseZshRecord(line)
-			if err := call(command, seenAt); err != nil {
-				return err
+		return walkLines(func(line string, oversized bool) error {
+			if oversized {
+				return nil
 			}
-		}
+			command, seenAt := parseZshRecord(line)
+			return call(command, seenAt)
+		})
 	default:
 		var command strings.Builder
 		var seenAt int64
 		timestamped := false
+		discard := false
 		flush := func() error {
-			err := call(command.String(), seenAt)
+			var err error
+			if !discard {
+				err = call(command.String(), seenAt)
+			}
 			command.Reset()
+			discard = false
 			return err
 		}
-		for scanner.Scan() {
-			line := scanner.Text()
+		if err := walkLines(func(line string, oversized bool) error {
 			if timestamp, ok := bashTimestamp(line); ok {
 				if err := flush(); err != nil {
 					return err
 				}
 				seenAt, timestamped = timestamp, true
-				continue
+				return nil
+			}
+			if oversized {
+				if timestamped {
+					command.Reset()
+					discard = true
+				}
+				return nil
 			}
 			if timestamped {
-				if command.Len() > 0 {
-					command.WriteByte('\n')
+				if discard {
+					return nil
 				}
-				command.WriteString(line)
+				length := command.Len() + len(line)
+				if command.Len() > 0 {
+					length++
+				}
+				if length > maxRecordLen {
+					command.Reset()
+					discard = true
+					return nil
+				}
+				if command.Len() > 0 {
+					_ = command.WriteByte('\n')
+				}
+				_, _ = command.WriteString(line)
 			} else if err := call(line, 0); err != nil {
 				return err
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
 		if err := flush(); err != nil {
 			return err
 		}
 	}
-	return scanner.Err()
+	return nil
 }
 
 func parseZshRecord(line string) (string, int64) {

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -96,13 +96,15 @@ func Scan(home string, getenv func(string) string, previous metadata.HistoryImpo
 func sourcePaths(home string, getenv func(string) string) []string {
 	paths := []string{
 		filepath.Join(home, ".zsh_history"),
+		filepath.Join(home, ".zhistory"),
 		filepath.Join(home, ".bash_history"),
 	}
 	if histfile := strings.TrimSpace(getenv("HISTFILE")); histfile != "" {
 		paths = append(paths, expandHome(histfile, home))
 	}
 	if zdotdir := strings.TrimSpace(getenv("ZDOTDIR")); zdotdir != "" {
-		paths = append(paths, filepath.Join(expandHome(zdotdir, home), ".zsh_history"))
+		zshHome := expandHome(zdotdir, home)
+		paths = append(paths, filepath.Join(zshHome, ".zsh_history"), filepath.Join(zshHome, ".zhistory"))
 	}
 	dataHome := strings.TrimSpace(getenv("XDG_DATA_HOME"))
 	if dataHome == "" {

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -146,14 +146,44 @@ func TestScanRecoversAfterHistoryRewriteWithoutReplaying(t *testing.T) {
 func TestScanAllStandardHistoriesAndDeduplicatesEndpoints(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".zsh_history"), "ssh dev@shared.example.com\n")
+	writeFile(t, filepath.Join(home, ".zhistory"), "ssh zhistory.example.com\n")
 	writeFile(t, filepath.Join(home, ".bash_history"), "ssh dev@shared.example.com\nssh bash.example.com\n")
 	writeFile(t, filepath.Join(home, ".local", "share", "fish", "fish_history"), "- cmd: ssh fish.example.com\n  when: 1700000000\n")
 	state, errs := Scan(home, func(string) string { return "" }, metadata.HistoryImport{}, nil)
 	if len(errs) != 0 {
 		t.Fatal(errs)
 	}
-	if len(state.Pending) != 3 {
+	if len(state.Pending) != 4 {
 		t.Fatalf("pending = %+v", state.Pending)
+	}
+}
+
+func TestSourcePathsIncludeCommonZshLocations(t *testing.T) {
+	home := t.TempDir()
+	zdotdir := filepath.Join(home, "zsh")
+	paths := sourcePaths(home, func(name string) string {
+		if name == "ZDOTDIR" {
+			return zdotdir
+		}
+		return ""
+	})
+	want := []string{
+		filepath.Join(home, ".zsh_history"),
+		filepath.Join(home, ".zhistory"),
+		filepath.Join(zdotdir, ".zsh_history"),
+		filepath.Join(zdotdir, ".zhistory"),
+	}
+	for _, path := range want {
+		found := false
+		for _, candidate := range paths {
+			if candidate == path {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("source paths do not include %q: %v", path, paths)
+		}
 	}
 }
 

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,0 +1,200 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"bast/internal/metadata"
+	"bast/internal/sshconfig"
+)
+
+func TestParseSSH(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    metadata.HistorySuggestion
+		ok      bool
+	}{
+		{name: "destination", command: "ssh ubuntu@example.com", want: metadata.HistorySuggestion{Alias: "ubuntu-example.com", Target: "example.com", HostName: "example.com", User: "ubuntu"}, ok: true},
+		{name: "options", command: `ssh -p2222 -i ~/.ssh/work -J jump -l root example.com uptime`, want: metadata.HistorySuggestion{Alias: "root-example.com", Target: "example.com", HostName: "example.com", User: "root", Port: "2222", IdentityFile: "~/.ssh/work", ProxyJump: "jump"}, ok: true},
+		{name: "config options", command: `command ssh -o User=deploy -oHostName=10.0.0.4 -o "Port 2200" prod`, want: metadata.HistorySuggestion{Alias: "deploy-10.0.0.4", Target: "prod", HostName: "10.0.0.4", User: "deploy", Port: "2200"}, ok: true},
+		{name: "quoted", command: `exec -- /usr/bin/ssh "dev@example.com" && echo done`, want: metadata.HistorySuggestion{Alias: "dev-example.com", Target: "example.com", HostName: "example.com", User: "dev"}, ok: true},
+		{name: "relative identity omitted", command: `ssh -i keys/work.pem host`, want: metadata.HistorySuggestion{Alias: "host", Target: "host", HostName: "host"}, ok: true},
+		{name: "environment identity", command: `ssh -i '${HOME}/.ssh/work' host`, want: metadata.HistorySuggestion{Alias: "host", Target: "host", HostName: "host", IdentityFile: "${HOME}/.ssh/work"}, ok: true},
+		{name: "custom config rejected", command: "ssh -F other.conf prod", ok: false},
+		{name: "proxy command rejected", command: `ssh -o ProxyCommand="nc gateway %h %p" prod`, ok: false},
+		{name: "config query rejected", command: "ssh -G prod", ok: false},
+		{name: "expansion rejected", command: `ssh "$TARGET"`, ok: false},
+		{name: "nested command rejected", command: "cd /tmp && ssh prod", ok: false},
+		{name: "not ssh", command: "scp file prod:/tmp", ok: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := parseSSH(test.command)
+			if ok != test.ok {
+				t.Fatalf("parseSSH ok = %v, want %v: %+v", ok, test.ok, got)
+			}
+			if !ok {
+				return
+			}
+			got.ID = ""
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("parseSSH = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWalkRecords(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		input  string
+		want   []record
+	}{
+		{name: "zsh extended", format: "zsh", input: ": 1700000000:2;ssh one\nssh two\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two"}}},
+		{name: "bash timestamps", format: "bash", input: "#1700000000\nssh one\n#1700000001\nssh two\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two", seenAt: 1700000001}}},
+		{name: "bash plain", format: "bash", input: "ls\nssh one\n", want: []record{{command: "ls"}, {command: "ssh one"}}},
+		{name: "fish", format: "fish", input: "- cmd: ssh one\n  when: 1700000000\n- cmd: ssh two\n  when: 1700000001\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two", seenAt: 1700000001}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got []record
+			if err := walkRecords(strings.NewReader(test.input), test.format, func(item record) error {
+				got = append(got, item)
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("records = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestScanPersistsPendingAndReadsOnlyNewRecords(t *testing.T) {
+	home := t.TempDir()
+	zsh := filepath.Join(home, ".zsh_history")
+	writeFile(t, zsh, ": 1700000000:0;ssh ubuntu@example.com\nssh root@example.com\nssh existing\n")
+	getenv := func(string) string { return "" }
+	existing := []sshconfig.Host{{Alias: "existing"}}
+
+	first, errs := Scan(home, getenv, metadata.HistoryImport{}, existing)
+	if len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	if len(first.Pending) != 2 {
+		t.Fatalf("pending = %+v", first.Pending)
+	}
+	if first.Pending[0].Alias != "root-example.com" || first.Pending[1].Alias != "ubuntu-example.com" {
+		t.Fatalf("unexpected ordering or aliases: %+v", first.Pending)
+	}
+
+	first.Pending = first.Pending[1:]
+	second, errs := Scan(home, getenv, first, existing)
+	if len(errs) != 0 || len(second.Pending) != 1 || second.Pending[0].User != "ubuntu" {
+		t.Fatalf("old dismissed entry returned: pending=%+v errors=%v", second.Pending, errs)
+	}
+
+	appendFile(t, zsh, "ssh root@example.com\n")
+	third, errs := Scan(home, getenv, second, existing)
+	if len(errs) != 0 || len(third.Pending) != 2 {
+		t.Fatalf("new occurrence was not suggested: pending=%+v errors=%v", third.Pending, errs)
+	}
+}
+
+func TestScanRecoversAfterHistoryRewriteWithoutReplaying(t *testing.T) {
+	home := t.TempDir()
+	zsh := filepath.Join(home, ".zsh_history")
+	var initial strings.Builder
+	for i := 0; i < 12; i++ {
+		initial.WriteString("echo ")
+		initial.WriteString(string(rune('a' + i)))
+		initial.WriteByte('\n')
+	}
+	initial.WriteString("ssh old.example.com\n")
+	writeFile(t, zsh, initial.String())
+	first, errs := Scan(home, func(string) string { return "" }, metadata.HistoryImport{}, nil)
+	if len(errs) != 0 || len(first.Pending) != 1 {
+		t.Fatalf("initial scan: pending=%+v errors=%v", first.Pending, errs)
+	}
+	first.Pending = nil
+
+	lines := strings.Split(strings.TrimSpace(initial.String()), "\n")
+	rewritten := strings.Join(lines[4:], "\n") + "\nssh new.example.com\n"
+	writeFile(t, zsh, rewritten)
+	second, errs := Scan(home, func(string) string { return "" }, first, nil)
+	if len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	if len(second.Pending) != 1 || second.Pending[0].HostName != "new.example.com" {
+		t.Fatalf("rewrite pending = %+v", second.Pending)
+	}
+
+	writeFile(t, zsh, "ssh old.example.com\nssh unrelated.example.com\n")
+	second.Pending = nil
+	third, errs := Scan(home, func(string) string { return "" }, second, nil)
+	if len(errs) != 0 || len(third.Pending) != 0 {
+		t.Fatalf("unanchored rewrite replayed entries: pending=%+v errors=%v", third.Pending, errs)
+	}
+}
+
+func TestScanAllStandardHistoriesAndDeduplicatesEndpoints(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".zsh_history"), "ssh dev@shared.example.com\n")
+	writeFile(t, filepath.Join(home, ".bash_history"), "ssh dev@shared.example.com\nssh bash.example.com\n")
+	writeFile(t, filepath.Join(home, ".local", "share", "fish", "fish_history"), "- cmd: ssh fish.example.com\n  when: 1700000000\n")
+	state, errs := Scan(home, func(string) string { return "" }, metadata.HistoryImport{}, nil)
+	if len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	if len(state.Pending) != 3 {
+		t.Fatalf("pending = %+v", state.Pending)
+	}
+}
+
+func TestScanLargeHistoryRetainsOnlyUniqueSSHDestinations(t *testing.T) {
+	home := t.TempDir()
+	var content strings.Builder
+	for i := 0; i < 25_000; i++ {
+		content.WriteString("echo ordinary-command\n")
+	}
+	content.WriteString("ssh ops@large.example.com\nssh ops@large.example.com\n")
+	writeFile(t, filepath.Join(home, ".bash_history"), content.String())
+	state, errs := Scan(home, func(string) string { return "" }, metadata.HistoryImport{}, nil)
+	if len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	if len(state.Pending) != 1 || state.Pending[0].Alias != "ops-large.example.com" {
+		t.Fatalf("pending = %+v", state.Pending)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendFile(t *testing.T, path, content string) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,9 +1,11 @@
 package history
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -57,7 +59,9 @@ func TestWalkRecords(t *testing.T) {
 	}{
 		{name: "zsh extended", format: "zsh", input: ": 1700000000:2;ssh one\nssh two\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two"}}},
 		{name: "bash timestamps", format: "bash", input: "#1700000000\nssh one\n#1700000001\nssh two\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two", seenAt: 1700000001}}},
+		{name: "bash multiline", format: "bash", input: "#1700000000\necho one \\\n  two\n#1700000001\nssh next\n", want: []record{{command: "echo one \\\n  two", seenAt: 1700000000}, {command: "ssh next", seenAt: 1700000001}}},
 		{name: "bash plain", format: "bash", input: "ls\nssh one\n", want: []record{{command: "ls"}, {command: "ssh one"}}},
+		{name: "oversized record", format: "bash", input: "ssh before\n" + strings.Repeat("x", maxRecordLen+1) + "\nssh after\n", want: []record{{command: "ssh before"}, {command: "ssh after"}}},
 		{name: "fish", format: "fish", input: "- cmd: ssh one\n  when: 1700000000\n- cmd: ssh two\n  when: 1700000001\n", want: []record{{command: "ssh one", seenAt: 1700000000}, {command: "ssh two", seenAt: 1700000001}}},
 	}
 	for _, test := range tests {
@@ -143,6 +147,26 @@ func TestScanRecoversAfterHistoryRewriteWithoutReplaying(t *testing.T) {
 	}
 }
 
+func TestScanAdvancesPastOversizedRecord(t *testing.T) {
+	home := t.TempDir()
+	bash := filepath.Join(home, ".bash_history")
+	writeFile(t, bash, "ssh before.example.com\n"+strings.Repeat("x", maxRecordLen+1)+"\nssh after.example.com\n")
+
+	first, errs := Scan(home, func(string) string { return "" }, metadata.HistoryImport{}, nil)
+	if len(errs) != 0 || len(first.Pending) != 2 {
+		t.Fatalf("initial scan: pending=%+v errors=%v", first.Pending, errs)
+	}
+	if first.Sources[bash].Offset != int64(len("ssh before.example.com\n")+maxRecordLen+1+len("\nssh after.example.com\n")) {
+		t.Fatalf("checkpoint did not advance: %+v", first.Sources[bash])
+	}
+
+	first.Pending = nil
+	second, errs := Scan(home, func(string) string { return "" }, first, nil)
+	if len(errs) != 0 || len(second.Pending) != 0 {
+		t.Fatalf("oversized record was replayed: pending=%+v errors=%v", second.Pending, errs)
+	}
+}
+
 func TestScanAllStandardHistoriesAndDeduplicatesEndpoints(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".zsh_history"), "ssh dev@shared.example.com\n")
@@ -174,16 +198,58 @@ func TestSourcePathsIncludeCommonZshLocations(t *testing.T) {
 		filepath.Join(zdotdir, ".zhistory"),
 	}
 	for _, path := range want {
-		found := false
-		for _, candidate := range paths {
-			if candidate == path {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(paths, path) {
 			t.Errorf("source paths do not include %q: %v", path, paths)
 		}
+	}
+}
+
+func TestSourcePathsEnvironmentLocations(t *testing.T) {
+	home := t.TempDir()
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    string
+		wantLen int
+	}{
+		{name: "HISTFILE", env: map[string]string{"HISTFILE": "~/custom/history"}, want: filepath.Join(home, "custom", "history"), wantLen: 5},
+		{name: "XDG_DATA_HOME", env: map[string]string{"XDG_DATA_HOME": "~/data"}, want: filepath.Join(home, "data", "fish", "fish_history"), wantLen: 4},
+		{name: "fish session", env: map[string]string{"fish_history": "work"}, want: filepath.Join(home, ".local", "share", "fish", "work_history"), wantLen: 4},
+		{name: "clean deduplication", env: map[string]string{"HISTFILE": filepath.Join(home, "nested", "..", ".zhistory")}, want: filepath.Join(home, ".zhistory"), wantLen: 4},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := sourcePaths(home, func(name string) string { return test.env[name] })
+			if !slices.Contains(paths, test.want) {
+				t.Fatalf("source paths do not include %q: %v", test.want, paths)
+			}
+			if len(paths) != test.wantLen {
+				t.Fatalf("source path count = %d, want %d: %v", len(paths), test.wantLen, paths)
+			}
+		})
+	}
+}
+
+func TestScanKeepsNewestPendingSuggestions(t *testing.T) {
+	previous := metadata.HistoryImport{Pending: make([]metadata.HistorySuggestion, maxPending+5)}
+	for i := range previous.Pending {
+		previous.Pending[i] = metadata.HistorySuggestion{
+			ID:       fmt.Sprintf("suggestion-%03d", i),
+			Target:   fmt.Sprintf("host-%03d.example.com", i),
+			HostName: fmt.Sprintf("host-%03d.example.com", i),
+			SeenAt:   int64(i),
+		}
+	}
+
+	state, errs := Scan(t.TempDir(), func(string) string { return "" }, previous, nil)
+	if len(errs) != 0 {
+		t.Fatal(errs)
+	}
+	if len(state.Pending) != maxPending {
+		t.Fatalf("pending count = %d, want %d", len(state.Pending), maxPending)
+	}
+	if state.Pending[0].ID != "suggestion-204" || state.Pending[maxPending-1].ID != "suggestion-005" {
+		t.Fatalf("pending bounds = %q ... %q", state.Pending[0].ID, state.Pending[maxPending-1].ID)
 	}
 }
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const CurrentVersion = 6
+const CurrentVersion = 7
 
 type Host struct {
 	Label           string     `json:"label,omitempty"`
@@ -31,6 +31,30 @@ type Host struct {
 type Preferences struct {
 	Sort            string   `json:"sort,omitempty"`
 	CollapsedGroups []string `json:"collapsedGroups,omitempty"`
+}
+
+type HistorySource struct {
+	Offset   int64    `json:"offset,omitempty"`
+	TailHash string   `json:"tailHash,omitempty"`
+	Anchors  []string `json:"anchors,omitempty"`
+}
+
+type HistorySuggestion struct {
+	ID           string `json:"id"`
+	Alias        string `json:"alias"`
+	Target       string `json:"target"`
+	HostName     string `json:"hostname"`
+	User         string `json:"user,omitempty"`
+	Port         string `json:"port,omitempty"`
+	IdentityFile string `json:"identityFile,omitempty"`
+	ProxyJump    string `json:"proxyJump,omitempty"`
+	Source       string `json:"source"`
+	SeenAt       int64  `json:"seenAt"`
+}
+
+type HistoryImport struct {
+	Sources map[string]HistorySource `json:"sources,omitempty"`
+	Pending []HistorySuggestion      `json:"pending,omitempty"`
 }
 
 type GCPIntegration struct {
@@ -77,13 +101,15 @@ type State struct {
 	Hosts        map[string]Host `json:"hosts"`
 	Preferences  Preferences     `json:"preferences,omitempty"`
 	Integrations Integrations    `json:"integrations,omitempty"`
+	History      HistoryImport   `json:"history,omitempty"`
 }
 
 type Store struct {
-	mu           sync.RWMutex
-	path         string
-	state        State
-	hostRevision atomic.Uint64
+	mu              sync.RWMutex
+	path            string
+	state           State
+	hostRevision    atomic.Uint64
+	historyRevision atomic.Uint64
 }
 
 func Open(path string) (*Store, error) {
@@ -309,6 +335,91 @@ func (s *Store) SetCollapsedGroups(groups []string) error {
 	return s.saveQuick()
 }
 
+func (s *Store) HistoryImport() HistoryImport {
+	history, _ := s.HistoryImportSnapshot()
+	return history
+}
+
+func (s *Store) HistoryImportSnapshot() (HistoryImport, uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneHistoryImport(s.state.History), s.historyRevision.Load()
+}
+
+func (s *Store) SetHistoryImport(history HistoryImport) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.state.History
+	s.state.History = cloneHistoryImport(history)
+	if err := s.save(); err != nil {
+		s.state.History = previous
+		return err
+	}
+	s.historyRevision.Add(1)
+	return nil
+}
+
+// CommitHistoryImport applies a scan only if the pending state has not changed
+// since the scan began. This prevents a background scan from resurrecting a
+// suggestion that the user dismissed while it was running.
+func (s *Store) CommitHistoryImport(expectedRevision uint64, history HistoryImport) (HistoryImport, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.historyRevision.Load() != expectedRevision {
+		return cloneHistoryImport(s.state.History), false, nil
+	}
+	previous := s.state.History
+	s.state.History = cloneHistoryImport(history)
+	if err := s.save(); err != nil {
+		s.state.History = previous
+		return cloneHistoryImport(previous), false, err
+	}
+	s.historyRevision.Add(1)
+	return cloneHistoryImport(s.state.History), true, nil
+}
+
+func (s *Store) DismissHistorySuggestion(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.state.History
+	next := cloneHistoryImport(previous)
+	next.Pending = removeHistorySuggestion(next.Pending, id)
+	s.state.History = next
+	if err := s.save(); err != nil {
+		s.state.History = previous
+		return err
+	}
+	s.historyRevision.Add(1)
+	return nil
+}
+
+// AcceptHistorySuggestion records host metadata and removes its history
+// suggestion in one state-file replacement. The SSH config write is managed by
+// the caller because it belongs to a separate file.
+func (s *Store) AcceptHistorySuggestion(alias string, host Host, suggestionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previousHost, hostExisted := s.state.Hosts[alias]
+	previousHistory := s.state.History
+	host.Tags = cleanTags(host.Tags)
+	s.state.Hosts[alias] = host
+	nextHistory := cloneHistoryImport(previousHistory)
+	nextHistory.Pending = removeHistorySuggestion(nextHistory.Pending, suggestionID)
+	s.state.History = nextHistory
+	if err := s.save(); err != nil {
+		if hostExisted {
+			s.state.Hosts[alias] = previousHost
+		} else {
+			delete(s.state.Hosts, alias)
+		}
+		s.state.History = previousHistory
+		return err
+	}
+	s.hostRevision.Add(1)
+	s.historyRevision.Add(1)
+	return nil
+}
+
 func (s *Store) Integrations() Integrations {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -391,6 +502,28 @@ func cloneHost(host Host) Host {
 		host.LastUsedAt = &lastUsedAt
 	}
 	return host
+}
+
+func cloneHistoryImport(history HistoryImport) HistoryImport {
+	out := HistoryImport{Pending: append([]HistorySuggestion(nil), history.Pending...)}
+	if history.Sources != nil {
+		out.Sources = make(map[string]HistorySource, len(history.Sources))
+		for path, source := range history.Sources {
+			source.Anchors = append([]string(nil), source.Anchors...)
+			out.Sources[path] = source
+		}
+	}
+	return out
+}
+
+func removeHistorySuggestion(suggestions []HistorySuggestion, id string) []HistorySuggestion {
+	out := make([]HistorySuggestion, 0, len(suggestions))
+	for _, suggestion := range suggestions {
+		if suggestion.ID != id {
+			out = append(out, suggestion)
+		}
+	}
+	return out
 }
 
 func cloneHosts(hosts map[string]Host) map[string]Host {

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -47,6 +47,81 @@ func TestStoreRoundTripAndPermissions(t *testing.T) {
 	}
 }
 
+func TestHistoryImportRoundTripAndAcceptance(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := HistoryImport{
+		Sources: map[string]HistorySource{"/home/test/.zsh_history": {Offset: 42, TailHash: "tail", Anchors: []string{"one", "two"}}},
+		Pending: []HistorySuggestion{{ID: "one", Alias: "dev-example.com", HostName: "example.com", User: "dev", Source: "zsh"}},
+	}
+	if err := store.SetHistoryImport(history); err != nil {
+		t.Fatal(err)
+	}
+	history.Pending[0].Alias = "mutated"
+	history.Sources["/home/test/.zsh_history"] = HistorySource{}
+	if got := store.HistoryImport(); got.Pending[0].Alias != "dev-example.com" || got.Sources["/home/test/.zsh_history"].Offset != 42 {
+		t.Fatalf("store retained caller-owned state: %+v", got)
+	}
+	if err := store.AcceptHistorySuggestion("dev-example.com", Host{Label: "Development"}, "one"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.HistoryImport(); len(got.Pending) != 0 {
+		t.Fatalf("accepted suggestion remained pending: %+v", got.Pending)
+	}
+	if got := store.Host("dev-example.com").Label; got != "Development" {
+		t.Fatalf("accepted host label = %q", got)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reopened.HistoryImport(); len(got.Pending) != 0 || got.Sources["/home/test/.zsh_history"].TailHash != "tail" {
+		t.Fatalf("reopened history = %+v", got)
+	}
+}
+
+func TestDismissHistorySuggestionLeavesOtherPendingEntries(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetHistoryImport(HistoryImport{Pending: []HistorySuggestion{{ID: "one"}, {ID: "two"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DismissHistorySuggestion("one"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.HistoryImport().Pending; len(got) != 1 || got[0].ID != "two" {
+		t.Fatalf("pending = %+v", got)
+	}
+}
+
+func TestHistoryScanCommitDoesNotResurrectDismissedSuggestion(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := HistoryImport{Pending: []HistorySuggestion{{ID: "one"}}}
+	if err := store.SetHistoryImport(original); err != nil {
+		t.Fatal(err)
+	}
+	_, revision := store.HistoryImportSnapshot()
+	if err := store.DismissHistorySuggestion("one"); err != nil {
+		t.Fatal(err)
+	}
+	committed, ok, err := store.CommitHistoryImport(revision, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || len(committed.Pending) != 0 || len(store.HistoryImport().Pending) != 0 {
+		t.Fatalf("stale scan committed: ok=%v state=%+v", ok, committed)
+	}
+}
+
 func TestStoreSerializesConcurrentWrites(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "state.json"))
 	if err != nil {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"bast/internal/cloud/sync"
+	"bast/internal/history"
 	"bast/internal/keys"
 	"bast/internal/metadata"
 	"bast/internal/openssh"
@@ -55,6 +56,7 @@ type form struct {
 	pastedPrivateKey string
 	pastedPublicKey  string
 	selecting        bool
+	validationError  string
 	input            textinput.Model
 }
 
@@ -97,6 +99,18 @@ type updateAvailableMsg struct {
 	suggestion string
 }
 
+type historyLoadedMsg struct {
+	suggestions []metadata.HistorySuggestion
+	warnings    int
+	err         error
+}
+
+type historyImportDoneMsg struct {
+	id    string
+	alias string
+	err   error
+}
+
 type hostRowsCache struct {
 	hostGeneration     uint64
 	metadataRevision   uint64
@@ -108,17 +122,21 @@ type hostRowsCache struct {
 }
 
 type App struct {
-	paths            paths.Paths
-	config           sshconfig.Manager
-	openSSH          openssh.Client
-	keyring          keys.Manager
-	metadata         *metadata.Store
-	syncer           *sync.Engine
-	hostMeta         map[string]metadata.Host
-	hostMetaRevision uint64
-	hostGeneration   uint64
-	collapseRevision uint64
-	hostRowsCache    hostRowsCache
+	paths                       paths.Paths
+	config                      sshconfig.Manager
+	openSSH                     openssh.Client
+	keyring                     keys.Manager
+	metadata                    *metadata.Store
+	syncer                      *sync.Engine
+	hostMeta                    map[string]metadata.Host
+	hostMetaRevision            uint64
+	hostGeneration              uint64
+	collapseRevision            uint64
+	hostRowsCache               hostRowsCache
+	historySuggestions          []metadata.HistorySuggestion
+	historyScanStarted          bool
+	historyImporting            string
+	historySuggestionsCollapsed bool
 
 	section           section
 	hosts             []sshconfig.Host
@@ -179,6 +197,7 @@ func New(p paths.Paths, client openssh.Client, version string) (*App, error) {
 		syncingProviders: map[string]bool{},
 	}
 	app.hostMeta, app.hostMetaRevision = store.HostsSnapshot()
+	app.historySuggestions = store.HistoryImport().Pending
 	return app, nil
 }
 
@@ -264,6 +283,30 @@ func (m *App) postPaintCmds() tea.Cmd {
 	return nil
 }
 
+func (m *App) historyScanCmd(hosts []sshconfig.Host) tea.Cmd {
+	if m.historyScanStarted {
+		return nil
+	}
+	m.historyScanStarted = true
+	hostSnapshot := append([]sshconfig.Host(nil), hosts...)
+	return func() tea.Msg {
+		var warningCount int
+		for range 3 {
+			previous, revision := m.metadata.HistoryImportSnapshot()
+			next, warnings := history.Scan(m.paths.Home, os.Getenv, previous, hostSnapshot)
+			warningCount = len(warnings)
+			committed, ok, err := m.metadata.CommitHistoryImport(revision, next)
+			if err != nil {
+				return historyLoadedMsg{suggestions: previous.Pending, warnings: warningCount, err: err}
+			}
+			if ok {
+				return historyLoadedMsg{suggestions: committed.Pending, warnings: warningCount}
+			}
+		}
+		return historyLoadedMsg{suggestions: m.metadata.HistoryImport().Pending, warnings: warningCount}
+	}
+}
+
 func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := message.(type) {
 	case tea.WindowSizeMsg:
@@ -298,6 +341,9 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			if cmd := m.postPaintCmds(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
+			if cmd := m.historyScanCmd(m.hosts); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 			return m, tea.Batch(cmds...)
 		}
 		previous := make(map[string]sshconfig.Host, len(m.hosts))
@@ -323,7 +369,35 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.postPaintCmds(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		if cmd := m.historyScanCmd(m.hosts); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		return m, tea.Batch(cmds...)
+	case historyLoadedMsg:
+		if msg.err == nil {
+			m.historySuggestions = msg.suggestions
+			m.clampCursor()
+		}
+		if msg.err != nil {
+			return m, m.setNotice("Couldn't save shell history scan")
+		}
+		if msg.warnings > 0 {
+			return m, m.setNotice("Some shell history couldn't be read")
+		}
+		return m, nil
+	case historyImportDoneMsg:
+		if m.historyImporting == msg.id {
+			m.historyImporting = ""
+		}
+		if msg.err != nil {
+			m.setError(msg.err)
+			return m, nil
+		}
+		m.removeHistorySuggestion(msg.id)
+		m.selectAfterLoadSection, m.selectAfterLoadName, m.selectAfterLoadGroup = hostsSection, msg.alias, false
+		m.loading = true
+		m.enriching = false
+		return m, tea.Batch(m.loadCmd(), m.setNotice("Host added"))
 	case reportResultMsg:
 		if msg.err != nil {
 			return m, m.setNotice("Couldn't send report")
@@ -434,6 +508,9 @@ func (m *App) View() tea.View {
 	view := tea.NewView(content)
 	view.AltScreen = true
 	view.MouseMode = tea.MouseModeCellMotion
+	if m.form != nil {
+		view.MouseMode = tea.MouseModeNone
+	}
 	view.WindowTitle = "Bast — SSH picker"
 	return view
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1425,36 +1425,59 @@ func TestDeletionFormsUseTheExactConfirmationAsAPlaceholder(t *testing.T) {
 	}
 }
 
-func TestErrorsUseAProminentScreenAndPreserveTheForm(t *testing.T) {
+func TestDeletionConfirmationMismatchStaysInline(t *testing.T) {
 	m := testApp(t)
 	m.hosts[0].Managed = true
 	m.openDeleteHostForm()
 	m.form.input.SetValue("wrong-name")
 	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	if !m.statusError || m.form == nil {
-		t.Fatal("failed deletion did not retain its form and error state")
+	if m.statusError || m.form == nil {
+		t.Fatal("confirmation mismatch left the form")
 	}
 
 	rendered := m.render()
-	for _, expected := range []string{"Action failed", "What happened", "Delete host — alpha failed", "confirmation did not match", "Your entries are still", "Space send report"} {
+	for _, expected := range []string{"Delete host — alpha", "Name to type", "alpha", "Name does not match the host label", "Type the name to confirm"} {
 		if !strings.Contains(rendered, expected) {
-			t.Fatalf("prominent error screen is missing %q:\n%s", expected, rendered)
+			t.Fatalf("inline confirmation error is missing %q:\n%s", expected, rendered)
 		}
 	}
-	if strings.Contains(rendered, "Type the name to confirm") {
-		t.Fatalf("the form was rendered over the error screen:\n%s", rendered)
+	if strings.Contains(rendered, "Action failed") {
+		t.Fatalf("confirmation mismatch opened the global error screen:\n%s", rendered)
 	}
 
-	m.Update(press("x"))
-	if !m.statusError {
-		t.Fatal("an unrelated key dismissed the error screen")
+	m.Update(press("backspace"))
+	if m.form.validationError != "" {
+		t.Fatal("editing did not clear the inline confirmation error")
 	}
-	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
-	if m.statusError || m.form == nil {
-		t.Fatal("Enter did not return to the retained form")
+}
+
+func TestDeletionConfirmationNameCanBeCopied(t *testing.T) {
+	m := testApp(t)
+	m.hosts[0].Managed = true
+	m.openDeleteHostForm()
+	if m.View().MouseMode != tea.MouseModeNone {
+		t.Fatal("delete form captured mouse input instead of allowing terminal text selection")
 	}
-	if !strings.Contains(m.render(), "Type the name to confirm") {
-		t.Fatal("the retained form was not restored")
+
+	_, cmd := m.Update(press("ctrl+y"))
+	if cmd == nil {
+		t.Fatal("copying the confirmation name returned no command")
+	}
+	if rendered := m.render(); !strings.Contains(rendered, "Name to type") || !strings.Contains(rendered, "Ctrl+Y copy name") {
+		t.Fatalf("copy affordance is not visible:\n%s", rendered)
+	}
+
+	m.form = nil
+	m.section = keysSection
+	m.keys = []keymodel.Key{{Name: "work", Managed: true}}
+	m.openDeleteKeyForm()
+	if target := destructiveConfirmationTarget(m.form); target != "work" {
+		t.Fatalf("key confirmation copy target = %q", target)
+	}
+	m.form.input.SetValue("wrong-name")
+	m.Update(press("enter"))
+	if m.form == nil || m.statusError || !strings.Contains(m.render(), "Name does not match the key name") {
+		t.Fatal("key confirmation mismatch did not stay inline")
 	}
 }
 

--- a/internal/ui/forms.go
+++ b/internal/ui/forms.go
@@ -102,6 +102,11 @@ func (m *App) updateForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	key := msg.String()
 	f := m.form
+	if key == "ctrl+y" {
+		if target := destructiveConfirmationTarget(f); target != "" {
+			return m, tea.Batch(tea.SetClipboard(target), m.setNotice("Confirmation name copied"))
+		}
+	}
 	item := &f.fields[f.index]
 	if f.selecting {
 		switch key {
@@ -193,6 +198,7 @@ func (m *App) updateForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if len(item.options) > 0 && !item.options[item.selected].custom {
 		return m, nil
 	}
+	f.validationError = ""
 	var cmd tea.Cmd
 	m.form.input, cmd = m.form.input.Update(msg)
 	return m, cmd
@@ -204,6 +210,7 @@ func isEditForm(f *form) bool {
 
 func (m *App) updateFormPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	f := m.form
+	f.validationError = ""
 	content := strings.TrimSpace(msg.Content)
 	if f.action == "key_import" && f.fields[f.index].label == "Private key" && strings.Contains(content, "PRIVATE KEY-----") {
 		f.pastedPrivateKey = content + "\n"
@@ -235,7 +242,7 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 		values[item.label] = item.value
 	}
 	switch f.action {
-	case "host_add", "host_edit":
+	case "host_add", "host_edit", "history_host_add":
 		group, label, pathErr := metadata.SplitLabelPath(values["Label"])
 		if pathErr != nil {
 			return m.formError(pathErr.Error())
@@ -262,8 +269,9 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 		}
 		oldAlias := values["Original label"]
 		var err error
-		if f.action == "host_add" {
-			_, err = m.config.Add(input)
+		var added sshconfig.Host
+		if f.action == "host_add" || f.action == "history_host_add" {
+			added, err = m.config.Add(input)
 		} else {
 			host, ok := m.findHost(oldAlias)
 			if !ok {
@@ -284,13 +292,25 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 					_ = m.metadata.RenameHost(oldAlias, input.Alias)
 				}
 			}
-			err = m.metadata.SetHost(input.Alias, meta)
+			if f.action == "history_host_add" {
+				err = m.metadata.AcceptHistorySuggestion(input.Alias, meta, values["History suggestion"])
+				if err != nil && added.ManagedID != "" {
+					if rollbackErr := m.config.Delete(added.ManagedID); rollbackErr != nil {
+						err = fmt.Errorf("%w; rollback failed: %v", err, rollbackErr)
+					}
+				}
+			} else {
+				err = m.metadata.SetHost(input.Alias, meta)
+			}
 		}
 		if err == nil {
+			if f.action == "history_host_add" {
+				m.removeHistorySuggestion(values["History suggestion"])
+			}
 			m.selectAfterLoadSection = hostsSection
 			if groupCreated {
 				m.selectAfterLoadName, m.selectAfterLoadGroup = group, true
-			} else if f.action == "host_add" {
+			} else if f.action == "host_add" || f.action == "history_host_add" {
 				m.selectAfterLoadName, m.selectAfterLoadGroup = input.Alias, false
 			}
 		}
@@ -322,7 +342,7 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 	case "host_delete":
 		alias := values["Alias"]
 		if values["Type the name to confirm"] != values["Confirmation"] {
-			return m.formError("confirmation did not match the exact host label")
+			return m.formValidationError("Name does not match the host label")
 		}
 		host, ok := m.findHost(alias)
 		if !ok {
@@ -397,13 +417,16 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 		if !ok {
 			return m.formError("key no longer exists")
 		}
+		if values["Type the name to confirm"] != key.Name {
+			return m.formValidationError("Name does not match the key name")
+		}
 		return m.finishMutation(m.keyring.Delete(key, values["Type the name to confirm"]), "Key permanently deleted")
 	case "sync_gcp_user", "sync_gcp_projects", "sync_gcp_sa_add", "sync_gcp_sa_remove", "sync_aws_user", "sync_aws_profiles", "sync_aws_regions", "sync_azure_user", "sync_azure_subscriptions", "sync_azure_resource_groups":
 		return m, m.submitSyncForm(f.action, values)
 	case "known_delete":
 		alias := values["Alias"]
 		if values["Type the name to confirm"] != values["Confirmation"] {
-			return m.formError("confirmation did not match the host label")
+			return m.formValidationError("Name does not match the host label")
 		}
 		host, ok := m.findHost(alias)
 		if !ok {
@@ -432,6 +455,32 @@ func (m *App) formError(message string) (tea.Model, tea.Cmd) {
 	m.statusID++
 	m.status, m.statusError = message, true
 	return m, nil
+}
+
+func (m *App) formValidationError(message string) (tea.Model, tea.Cmd) {
+	if m.form != nil {
+		m.form.validationError = message
+		m.form.input.Focus()
+	}
+	return m, nil
+}
+
+func destructiveConfirmationTarget(f *form) string {
+	if f == nil {
+		return ""
+	}
+	label := "Confirmation"
+	if f.action == "key_delete" {
+		label = "Key"
+	} else if f.action != "host_delete" && f.action != "known_delete" {
+		return ""
+	}
+	for _, item := range f.fields {
+		if item.label == label {
+			return item.value
+		}
+	}
+	return ""
 }
 
 func (m *App) openAddHostForm() {

--- a/internal/ui/history.go
+++ b/internal/ui/history.go
@@ -1,0 +1,171 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"bast/internal/metadata"
+	"bast/internal/sshconfig"
+)
+
+func (m *App) visibleHistorySuggestions() []metadata.HistorySuggestion {
+	query := strings.ToLower(m.searchText())
+	visible := make([]metadata.HistorySuggestion, 0, len(m.historySuggestions))
+	for _, suggestion := range m.historySuggestions {
+		if m.historySuggestionExists(suggestion) {
+			continue
+		}
+		if query != "" {
+			haystack := strings.ToLower(strings.Join([]string{
+				suggestion.Alias, suggestion.Target, suggestion.HostName,
+				suggestion.User, suggestion.Port, suggestion.Source,
+			}, " "))
+			if !strings.Contains(haystack, query) {
+				continue
+			}
+		}
+		visible = append(visible, suggestion)
+	}
+	return visible
+}
+
+func (m *App) historySuggestionExists(suggestion metadata.HistorySuggestion) bool {
+	port := suggestion.Port
+	if port == "" {
+		port = "22"
+	}
+	for _, host := range m.hosts {
+		if strings.EqualFold(host.Alias, suggestion.Target) {
+			return true
+		}
+		hostname := host.Resolved.HostName
+		if hostname == "" {
+			hostname = host.Alias
+		}
+		hostPort := host.Resolved.Port
+		if hostPort == "" {
+			hostPort = "22"
+		}
+		if strings.EqualFold(hostname, suggestion.HostName) &&
+			strings.EqualFold(host.Resolved.User, suggestion.User) && hostPort == port {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *App) selectedHistorySuggestion() (metadata.HistorySuggestion, bool) {
+	rows := m.hostListRows()
+	if m.cursor < 0 || m.cursor >= len(rows) || rows[m.cursor].suggestion == nil {
+		return metadata.HistorySuggestion{}, false
+	}
+	return *rows[m.cursor].suggestion, true
+}
+
+func (m *App) historySuggestionsHeaderSelected() bool {
+	rows := m.hostListRows()
+	return m.cursor >= 0 && m.cursor < len(rows) && rows[m.cursor].historyHeader
+}
+
+func (m *App) toggleHistorySuggestions() tea.Cmd {
+	if !m.historySuggestionsHeaderSelected() {
+		return nil
+	}
+	if m.searchText() != "" {
+		return m.setNotice("Clear the search filter to collapse suggestions")
+	}
+	m.historySuggestionsCollapsed = !m.historySuggestionsCollapsed
+	m.clampCursor()
+	return nil
+}
+
+func (m *App) removeHistorySuggestion(id string) {
+	for i, suggestion := range m.historySuggestions {
+		if suggestion.ID == id {
+			m.historySuggestions = append(m.historySuggestions[:i], m.historySuggestions[i+1:]...)
+			break
+		}
+	}
+	m.clampCursor()
+}
+
+func (m *App) dismissSelectedHistorySuggestion() tea.Cmd {
+	suggestion, ok := m.selectedHistorySuggestion()
+	if !ok {
+		return nil
+	}
+	if err := m.metadata.DismissHistorySuggestion(suggestion.ID); err != nil {
+		m.setError(err)
+		return nil
+	}
+	m.removeHistorySuggestion(suggestion.ID)
+	return m.setNotice("Suggestion dismissed")
+}
+
+func (m *App) importSelectedHistorySuggestion() (tea.Model, tea.Cmd) {
+	suggestion, ok := m.selectedHistorySuggestion()
+	if !ok || m.historyImporting != "" {
+		return m, nil
+	}
+	alias := m.availableHistoryAlias(suggestion.Alias)
+	input := historyHostInput(suggestion, alias)
+	m.historyImporting = suggestion.ID
+	return m, func() tea.Msg {
+		added, err := m.config.Add(input)
+		if err != nil {
+			return historyImportDoneMsg{id: suggestion.ID, alias: alias, err: fmt.Errorf("import history host: %w", err)}
+		}
+		if err := m.metadata.AcceptHistorySuggestion(alias, metadata.Host{}, suggestion.ID); err != nil {
+			rollbackErr := m.config.Delete(added.ManagedID)
+			if rollbackErr != nil {
+				err = fmt.Errorf("save imported host: %w; rollback failed: %v", err, rollbackErr)
+			} else {
+				err = fmt.Errorf("save imported host: %w", err)
+			}
+			return historyImportDoneMsg{id: suggestion.ID, alias: alias, err: err}
+		}
+		return historyImportDoneMsg{id: suggestion.ID, alias: alias}
+	}
+}
+
+func historyHostInput(suggestion metadata.HistorySuggestion, alias string) sshconfig.HostInput {
+	input := sshconfig.HostInput{
+		Alias: alias, HostName: suggestion.HostName, User: suggestion.User,
+		Port: suggestion.Port, IdentityFile: suggestion.IdentityFile, ProxyJump: suggestion.ProxyJump,
+	}
+	if input.IdentityFile != "" {
+		input.ExtraOptions = []string{"IdentitiesOnly yes"}
+	}
+	return input
+}
+
+func (m *App) availableHistoryAlias(preferred string) string {
+	if _, exists := m.findHost(preferred); !exists {
+		return preferred
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", preferred, suffix)
+		if _, exists := m.findHost(candidate); !exists {
+			return candidate
+		}
+	}
+}
+
+func (m *App) openHistoryHostForm() {
+	suggestion, ok := m.selectedHistorySuggestion()
+	if !ok {
+		return
+	}
+	alias := m.availableHistoryAlias(suggestion.Alias)
+	fields := hostFormFields(m, metadataHostValues{label: alias}, hostConnectionValues{
+		includeConnection: true,
+		hostname:          suggestion.HostName,
+		user:              suggestion.User,
+		port:              suggestion.Port,
+		identity:          suggestion.IdentityFile,
+		advanced:          sshconfig.AdvancedSettings{ProxyJump: suggestion.ProxyJump},
+	}, []field{{label: "History suggestion", value: suggestion.ID, hidden: true}})
+	m.openHostForm("Add host from history", "history_host_add", fields)
+}

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -1,0 +1,226 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"bast/internal/metadata"
+	"bast/internal/openssh"
+	"bast/internal/paths"
+)
+
+func historyTestApp(t *testing.T, suggestions ...metadata.HistorySuggestion) *App {
+	t.Helper()
+	p := paths.ForHome(t.TempDir())
+	app, err := New(p, openssh.Default(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := metadata.HistoryImport{Pending: append([]metadata.HistorySuggestion(nil), suggestions...)}
+	if err := app.metadata.SetHistoryImport(state); err != nil {
+		t.Fatal(err)
+	}
+	app.historySuggestions = state.Pending
+	if len(suggestions) > 0 {
+		app.cursor = 1
+	}
+	app.loading = false
+	app.width, app.height = 80, 24
+	return app
+}
+
+func testHistorySuggestion() metadata.HistorySuggestion {
+	return metadata.HistorySuggestion{
+		ID: "suggestion-1", Alias: "ubuntu-example.com", Target: "example.com",
+		HostName: "example.com", User: "ubuntu", Port: "2222", Source: "zsh",
+	}
+}
+
+func TestHistorySuggestionsFollowHostsAndUseSelectedDetail(t *testing.T) {
+	m := testApp(t)
+	m.historySuggestions = []metadata.HistorySuggestion{testHistorySuggestion()}
+	rows := m.hostListRows()
+	if len(rows) != 4 || !rows[2].historyHeader || rows[3].suggestion == nil {
+		t.Fatalf("host list rows = %+v", rows)
+	}
+	m.cursor = 3
+	view := m.renderHosts(m.styles())
+	for _, text := range []string{"ubuntu-example.com", "ubuntu@example.com:2222", "From zsh history", addAction} {
+		if !strings.Contains(view, text) {
+			t.Fatalf("history detail is missing %q:\n%s", text, view)
+		}
+	}
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "add") || !strings.Contains(footer, "dismiss") {
+		t.Fatalf("history footer = %q", footer)
+	}
+}
+
+func TestHistorySuggestionsParticipateInSearch(t *testing.T) {
+	m := testApp(t)
+	m.historySuggestions = []metadata.HistorySuggestion{testHistorySuggestion()}
+	m.search = "ubuntu"
+	rows := m.hostListRows()
+	if len(rows) != 2 || !rows[0].historyHeader || rows[1].suggestion == nil {
+		t.Fatalf("filtered rows = %+v", rows)
+	}
+	m.search = "missing"
+	if rows := m.hostListRows(); len(rows) != 0 {
+		t.Fatalf("non-matching rows = %+v", rows)
+	}
+}
+
+func TestSuggestedGroupCanCollapseAndExpand(t *testing.T) {
+	m := historyTestApp(t, testHistorySuggestion())
+	m.cursor = 0
+	if !m.historySuggestionsHeaderSelected() {
+		t.Fatal("suggested group header is not selectable")
+	}
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if !m.historySuggestionsCollapsed || len(m.hostListRows()) != 1 {
+		t.Fatalf("suggested group did not collapse: rows=%+v", m.hostListRows())
+	}
+	m.Update(press("space"))
+	if m.historySuggestionsCollapsed || len(m.hostListRows()) != 2 {
+		t.Fatalf("suggested group did not expand: rows=%+v", m.hostListRows())
+	}
+}
+
+func TestDismissHistorySuggestionPersists(t *testing.T) {
+	suggestion := testHistorySuggestion()
+	m := historyTestApp(t, suggestion)
+	_, cmd := m.Update(press("x"))
+	if cmd == nil {
+		t.Fatal("dismiss did not return a notice command")
+	}
+	if len(m.historySuggestions) != 0 || len(m.metadata.HistoryImport().Pending) != 0 {
+		t.Fatalf("suggestion was not dismissed: local=%+v stored=%+v", m.historySuggestions, m.metadata.HistoryImport().Pending)
+	}
+}
+
+func TestEnterImportsHistorySuggestion(t *testing.T) {
+	suggestion := testHistorySuggestion()
+	m := historyTestApp(t, suggestion)
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd == nil || m.historyImporting != suggestion.ID {
+		t.Fatalf("import did not start: id=%q cmd=%v", m.historyImporting, cmd)
+	}
+	if _, duplicate := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter})); duplicate != nil {
+		t.Fatal("duplicate history import was not blocked")
+	}
+	message := cmd()
+	done, ok := message.(historyImportDoneMsg)
+	if !ok || done.err != nil {
+		t.Fatalf("import result = %#v", message)
+	}
+	m.Update(done)
+	hosts, err := m.config.Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 1 || hosts[0].Alias != suggestion.Alias || hosts[0].Resolved.HostName != suggestion.HostName {
+		t.Fatalf("imported hosts = %+v", hosts)
+	}
+	if len(m.metadata.HistoryImport().Pending) != 0 || len(m.historySuggestions) != 0 {
+		t.Fatal("accepted suggestion remained pending")
+	}
+}
+
+func TestHistoryImportRollsBackSSHBlockWhenStateWriteFails(t *testing.T) {
+	suggestion := testHistorySuggestion()
+	m := historyTestApp(t, suggestion)
+	stateDir := filepath.Dir(m.paths.StateFile)
+	if err := os.Remove(m.paths.StateFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stateDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, cmd := m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	result := cmd().(historyImportDoneMsg)
+	if result.err == nil {
+		t.Fatal("history import unexpectedly succeeded")
+	}
+	hosts, err := m.config.Discover()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 0 {
+		t.Fatalf("failed import left an SSH host behind: %+v", hosts)
+	}
+}
+
+func TestReviewHistorySuggestionPrefillsExistingHostForm(t *testing.T) {
+	suggestion := testHistorySuggestion()
+	suggestion.IdentityFile = "~/.ssh/work"
+	suggestion.ProxyJump = "jump"
+	m := historyTestApp(t, suggestion)
+	m.Update(press("e"))
+	if m.form == nil || m.form.action != "history_host_add" {
+		t.Fatalf("review form = %+v", m.form)
+	}
+	for label, want := range map[string]string{
+		"Label": suggestion.Alias, "Hostname": suggestion.HostName, "User": suggestion.User,
+		"Port": suggestion.Port, "History suggestion": suggestion.ID,
+	} {
+		if got := formFieldByLabel(m, label).value; got != want {
+			t.Fatalf("%s = %q, want %q", label, got, want)
+		}
+	}
+	if got := formFieldByLabel(m, "Identity file").value; got != suggestion.IdentityFile {
+		t.Fatalf("identity = %q", got)
+	}
+}
+
+func TestHistoryAddButtonIsClickable(t *testing.T) {
+	m := historyTestApp(t, testHistorySuggestion())
+	layout := m.panelLayout()
+	buttonX, buttonY, _ := m.hostActionButtonBounds(layout, addAction)
+	_, cmd := m.Update(tea.MouseClickMsg(tea.Mouse{X: buttonX, Y: buttonY, Button: tea.MouseLeft}))
+	if cmd == nil {
+		t.Fatal("history Add button did not trigger import")
+	}
+}
+
+func TestHistorySuggestionRendersInMobileLayout(t *testing.T) {
+	m := historyTestApp(t, testHistorySuggestion())
+	m.width, m.height = 40, 20
+	view := m.renderHosts(m.styles())
+	if !strings.Contains(view, "ubuntu-example.com") || !strings.Contains(view, addAction) {
+		t.Fatalf("mobile history suggestion is incomplete:\n%s", view)
+	}
+}
+
+func TestHistoryScanCommandPersistsNewSuggestions(t *testing.T) {
+	m := historyTestApp(t)
+	historyPath := filepath.Join(m.paths.Home, ".zsh_history")
+	if err := writeHistoryFixture(historyPath, "ssh deploy@example.com\n"); err != nil {
+		t.Fatal(err)
+	}
+	message := m.historyScanCmd(nil)()
+	loaded, ok := message.(historyLoadedMsg)
+	if !ok || loaded.err != nil || len(loaded.suggestions) != 1 {
+		t.Fatalf("scan result = %#v", message)
+	}
+	m.Update(loaded)
+	if len(m.historySuggestions) != 1 || len(m.metadata.HistoryImport().Pending) != 1 {
+		t.Fatal("scanned suggestion was not loaded and persisted")
+	}
+	if m.historyScanCmd(nil) != nil {
+		t.Fatal("history scan started more than once")
+	}
+}
+
+func writeHistoryFixture(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/internal/ui/host_form.go
+++ b/internal/ui/host_form.go
@@ -26,7 +26,7 @@ type hostHubItem struct {
 
 func isHostForm(f *form) bool {
 	switch f.action {
-	case "host_add", "host_edit", "metadata_edit":
+	case "host_add", "host_edit", "history_host_add", "metadata_edit":
 		return true
 	default:
 		return false

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -108,10 +108,19 @@ func (m *App) updateMouse(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if m.section == hostsSection {
+		action := ""
 		if _, ok := m.selectedHost(); ok {
-			btnX, btnY, btnWidth := m.connectButtonBounds(layout)
+			action = connectAction
+		} else if _, ok := m.selectedHistorySuggestion(); ok {
+			action = addAction
+		}
+		if action != "" {
+			btnX, btnY, btnWidth := m.hostActionButtonBounds(layout, action)
 			inDetail := layout.mobile || mouse.X > listWidth
 			if inDetail && mouse.Y == btnY && mouse.X >= btnX && mouse.X < btnX+btnWidth {
+				if action == addAction {
+					return m.importSelectedHistorySuggestion()
+				}
 				return m.connectSelected()
 			}
 		}
@@ -335,6 +344,9 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "space":
 		if m.section == hostsSection {
+			if m.historySuggestionsHeaderSelected() {
+				return m, m.toggleHistorySuggestions()
+			}
 			return m, m.toggleSelectedGroup()
 		}
 	case "[":
@@ -359,7 +371,9 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.section == hostsSection {
-			if _, ok := m.selectedGroupHeader(); ok {
+			if _, ok := m.selectedHistorySuggestion(); ok {
+				m.openHistoryHostForm()
+			} else if _, ok := m.selectedGroupHeader(); ok {
 				m.openEditGroupForm()
 			} else {
 				if host, ok := m.selectedHost(); ok && (m.loading || m.enriching) && host.Resolved.HostName == "" {
@@ -384,6 +398,9 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.openImportForm()
 		}
 	case "x":
+		if m.section == hostsSection {
+			return m, m.dismissSelectedHistorySuggestion()
+		}
 		if m.section == keysSection {
 			m.openExportForm()
 		}
@@ -445,6 +462,12 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m.updateSyncKeys(key)
 		}
 		if m.section == hostsSection {
+			if m.historySuggestionsHeaderSelected() {
+				return m, m.toggleHistorySuggestions()
+			}
+			if _, ok := m.selectedHistorySuggestion(); ok {
+				return m.importSelectedHistorySuggestion()
+			}
 			if _, groupSelected := m.selectedGroupHeader(); groupSelected {
 				return m, m.toggleSelectedGroup()
 			}

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -127,12 +127,14 @@ func (m *App) filteredHostsWithMetadata(hostMetadata map[string]metadata.Host) [
 }
 
 type hostRow struct {
-	group  string
-	label  string
-	host   sshconfig.Host
-	header bool
-	count  int
-	depth  int
+	group         string
+	label         string
+	host          sshconfig.Host
+	suggestion    *metadata.HistorySuggestion
+	historyHeader bool
+	header        bool
+	count         int
+	depth         int
 }
 
 type hostGroup struct {
@@ -210,6 +212,23 @@ func (m *App) hostRows() []hostRow {
 		hostGeneration: m.hostGeneration, metadataRevision: m.hostMetaRevision,
 		collapseGeneration: m.collapseRevision, search: search,
 		showHidden: m.showHidden, hostSignature: hostSignature, rows: rows,
+	}
+	return rows
+}
+
+func (m *App) hostListRows() []hostRow {
+	rows := append([]hostRow(nil), m.hostRows()...)
+	suggestions := m.visibleHistorySuggestions()
+	if len(suggestions) == 0 {
+		return rows
+	}
+	rows = append(rows, hostRow{historyHeader: true, header: true, label: "(Suggested)", count: len(suggestions)})
+	if m.historySuggestionsCollapsed && m.searchText() == "" {
+		return rows
+	}
+	for i := range suggestions {
+		suggestion := suggestions[i]
+		rows = append(rows, hostRow{suggestion: &suggestion, depth: 1})
 	}
 	return rows
 }
@@ -331,15 +350,15 @@ func (m *App) filteredKeys() []keys.Key {
 	return out
 }
 func (m *App) selectedHost() (sshconfig.Host, bool) {
-	rows := m.hostRows()
-	if m.cursor >= 0 && m.cursor < len(rows) && !rows[m.cursor].header {
+	rows := m.hostListRows()
+	if m.cursor >= 0 && m.cursor < len(rows) && !rows[m.cursor].header && rows[m.cursor].suggestion == nil {
 		return rows[m.cursor].host, true
 	}
 	return sshconfig.Host{}, false
 }
 
 func (m *App) selectedGroup() (string, bool) {
-	rows := m.hostRows()
+	rows := m.hostListRows()
 	if m.cursor < 0 || m.cursor >= len(rows) {
 		return "", false
 	}
@@ -348,8 +367,8 @@ func (m *App) selectedGroup() (string, bool) {
 }
 
 func (m *App) selectedGroupHeader() (string, bool) {
-	rows := m.hostRows()
-	if m.cursor < 0 || m.cursor >= len(rows) || !rows[m.cursor].header {
+	rows := m.hostListRows()
+	if m.cursor < 0 || m.cursor >= len(rows) || !rows[m.cursor].header || rows[m.cursor].historyHeader {
 		return "", false
 	}
 	return rows[m.cursor].group, true
@@ -452,7 +471,7 @@ func (m *App) findKey(name string) (keys.Key, bool) {
 func (m *App) itemCount() int {
 	switch m.section {
 	case hostsSection:
-		return len(m.hostRows())
+		return len(m.hostListRows())
 	case keysSection:
 		return len(m.filteredKeys())
 	default:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -10,12 +10,14 @@ import (
 
 	"bast/internal/cloud/sync"
 	"bast/internal/keys"
+	"bast/internal/metadata"
 	"bast/internal/sshconfig"
 	"bast/internal/telemetry"
 )
 
 const (
 	connectAction        = " Connect "
+	addAction            = " Add "
 	connectActionRow     = 0
 	mobileScrollbarWidth = 3
 
@@ -24,7 +26,11 @@ const (
 )
 
 func (m *App) connectButtonBounds(layout panelLayout) (x, y, width int) {
-	btn := m.styles().title.Render(connectAction)
+	return m.hostActionButtonBounds(layout, connectAction)
+}
+
+func (m *App) hostActionButtonBounds(layout panelLayout, action string) (x, y, width int) {
+	btn := m.styles().title.Render(action)
 	width = lipgloss.Width(btn)
 	y = layout.detailTop + connectActionRow
 	x = max(0, m.terminalWidth()-width-2)
@@ -129,7 +135,7 @@ func (m *App) renderTabs(s styleSet) string {
 }
 
 func (m *App) renderHosts(s styleSet) string {
-	rowsData := m.hostRows()
+	rowsData := m.hostListRows()
 	if len(rowsData) == 0 {
 		if m.loading {
 			return "\n  " + s.muted.Render("Loading hosts…")
@@ -156,6 +162,31 @@ func (m *App) renderHosts(s styleSet) string {
 	var list strings.Builder
 	for i := start; i < min(len(rowsData), start+listHeight); i++ {
 		row := rowsData[i]
+		if row.historyHeader {
+			indicator := "▾"
+			if m.historySuggestionsCollapsed && m.searchText() == "" {
+				indicator = "▸"
+			}
+			line := indicator + " " + row.label + " " + s.muted.Render(fmt.Sprintf("(%d)", row.count))
+			if i == m.cursor {
+				line = s.selected.Width(rowWidth).Render(line)
+			} else {
+				line = s.muted.Width(rowWidth).Render(line)
+			}
+			list.WriteString(line + "\n")
+			continue
+		}
+		if row.suggestion != nil {
+			indent := strings.Repeat("  ", row.depth)
+			line := indent + "＋ " + truncate(row.suggestion.Alias, max(2, rowWidth-lipgloss.Width(indent)-4))
+			if i == m.cursor {
+				line = s.selected.Width(rowWidth).Render(line)
+			} else {
+				line = s.muted.Width(rowWidth).Render(line)
+			}
+			list.WriteString(line + "\n")
+			continue
+		}
 		if row.header {
 			indent := strings.Repeat("  ", row.depth)
 			indicator := "▾"
@@ -215,7 +246,11 @@ func (m *App) renderHosts(s styleSet) string {
 	}
 	detailContent := ""
 	if m.cursor >= 0 && m.cursor < len(rowsData) {
-		if rowsData[m.cursor].header {
+		if rowsData[m.cursor].historyHeader {
+			detailContent = m.renderHistorySuggestionsDetail(s, rowsData[m.cursor].count, detailWidth)
+		} else if rowsData[m.cursor].suggestion != nil {
+			detailContent = m.renderHistorySuggestionDetail(s, *rowsData[m.cursor].suggestion, detailWidth)
+		} else if rowsData[m.cursor].header {
 			detailContent = m.renderGroupDetail(s, rowsData[m.cursor], detailWidth)
 		} else {
 			detailContent = m.renderHostDetail(s, rowsData[m.cursor].host, detailWidth)
@@ -228,6 +263,46 @@ func (m *App) renderHosts(s styleSet) string {
 	}
 	divider := s.rule.Render(strings.TrimSuffix(strings.Repeat("│\n", bodyHeight), "\n"))
 	return lipgloss.JoinHorizontal(lipgloss.Top, listPanel, divider, detail)
+}
+
+func (m *App) renderHistorySuggestionsDetail(s styleSet, count, width int) string {
+	state := "expanded"
+	if m.historySuggestionsCollapsed {
+		state = "collapsed"
+		if m.searchText() != "" {
+			state = "expanded for search"
+		}
+	}
+	return "  " + s.muted.Render("(Suggested)") + "\n" +
+		"  " + s.muted.Render(fmt.Sprintf("%d hosts · %s", count, state)) + "\n\n" +
+		"  " + s.muted.Render(truncate("␣ collapse or expand", max(4, width-3)))
+}
+
+func (m *App) renderHistorySuggestionDetail(s styleSet, suggestion metadata.HistorySuggestion, width int) string {
+	var b strings.Builder
+	addButton := s.title.Render(addAction)
+	title := truncate(suggestion.Alias, max(4, width-lipgloss.Width(addButton)-4))
+	gap := max(1, width-2-lipgloss.Width(title)-lipgloss.Width(addButton))
+	b.WriteString("  " + s.active.Render(title) + strings.Repeat(" ", gap) + addButton + "\n")
+	destination := suggestion.HostName
+	if suggestion.User != "" {
+		destination = suggestion.User + "@" + destination
+	}
+	if suggestion.Port != "" && suggestion.Port != "22" {
+		destination += ":" + suggestion.Port
+	}
+	b.WriteString("  " + s.value.Render(truncate(destination, max(4, width-3))) + "\n")
+	b.WriteString("  " + s.muted.Render("From "+suggestion.Source+" history") + "\n\n")
+	b.WriteString("  " + s.muted.Render("Access") + "\n")
+	identity := suggestion.IdentityFile
+	if identity == "" {
+		identity = "agent/defaults"
+	}
+	b.WriteString(compactRow(s, "Auth", identity, width))
+	if suggestion.ProxyJump != "" {
+		b.WriteString(compactRow(s, "Jump", suggestion.ProxyJump, width))
+	}
+	return b.String()
 }
 
 func (m *App) cloudSyncGroupHasError(group string) bool {
@@ -485,6 +560,9 @@ func (m *App) renderForm(s styleSet) string {
 	var b strings.Builder
 	current, total := formProgress(f)
 	b.WriteString("\n  " + s.active.Render(f.title) + "  " + s.muted.Render(fmt.Sprintf("%d/%d", current, total)) + "\n\n")
+	if target := destructiveConfirmationTarget(f); target != "" {
+		b.WriteString("  " + s.label.Render("Name to type") + s.value.Render(target) + "\n\n")
+	}
 	for i, item := range f.fields {
 		if item.hidden || i > f.revealed {
 			continue
@@ -515,6 +593,9 @@ func (m *App) renderForm(s styleSet) string {
 				}
 			} else {
 				b.WriteString("    " + f.input.View() + "\n")
+			}
+			if f.validationError != "" {
+				b.WriteString("    " + s.error.Render("✕ "+f.validationError) + "\n")
 			}
 			if item.label == "Color" {
 				colour := strings.TrimSpace(f.input.Value())
@@ -563,6 +644,9 @@ func (m *App) formHint() string {
 		if f.action == "host_delete" || f.action == "key_delete" || f.action == "known_delete" {
 			action = "󰌑 delete"
 		}
+	}
+	if destructiveConfirmationTarget(f) != "" {
+		action += " • Ctrl+Y copy name"
 	}
 	if f.selecting {
 		return action + " • Esc/⌫ close"
@@ -644,9 +728,10 @@ func helpSections() []helpSection {
 		{
 			title: "Hosts",
 			bindings: []helpBinding{
-				{"󰌑", "Connect"},
+				{"󰌑", "Connect or add suggestion"},
 				{"a", "Add host"},
-				{"e", "Edit host"},
+				{"e", "Edit or review suggestion"},
+				{"x", "Dismiss history suggestion"},
 				{"d", "Delete host"},
 				{"␣", "Collapse or expand group"},
 				{"[", "Collapse all groups"},
@@ -829,8 +914,12 @@ func (m *App) renderFooter(s styleSet) string {
 	if m.form != nil {
 		hint = m.formHint()
 	} else if m.section == hostsSection {
-		collapse := "␣ " + m.collapseActionLabel()
-		if _, groupSelected := m.selectedGroupHeader(); groupSelected {
+		if _, suggestionSelected := m.selectedHistorySuggestion(); suggestionSelected {
+			hint = "󰌑 add • e review • x dismiss • v about • ? help"
+		} else if m.historySuggestionsHeaderSelected() {
+			hint = "␣ collapse/expand • v about • ? help"
+		} else if _, groupSelected := m.selectedGroupHeader(); groupSelected {
+			collapse := "␣ " + m.collapseActionLabel()
 			if m.isMobileLayout() {
 				hint = "↑/↓ or j/k move • e rename • " + collapse + " • a add • v about • ? help"
 			} else {
@@ -839,7 +928,7 @@ func (m *App) renderFooter(s styleSet) string {
 		} else if m.isMobileLayout() {
 			hint = "↑/↓ or j/k move • enter/click Connect • a add • v about • ? help"
 		} else {
-			hint = "󰌑 connect • " + collapse + " • a add • h hide • v about • ? help"
+			hint = "󰌑 connect • ␣ " + m.collapseActionLabel() + " • a add • h hide • v about • ? help"
 		}
 	} else if m.section == keysSection {
 		hint = "a generate • i import • u add to server • x export • v about • ? help"


### PR DESCRIPTION
closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bast now scans common zsh, bash, and fish history in the background to surface unconfigured SSH destinations as “(Suggested)” entries.
  * Suggested destinations support search, collapse/expand, and keyboard controls; **Enter** now triggers “connect/add suggestion” in the Hosts view.
  * Reviewing a suggestion pre-fills the add-from-history form and lets you import it into your config.
  * Added **Ctrl+Y** to copy destructive confirmation names.

* **Bug Fixes**
  * Confirmation mismatches and validation errors now remain inline within the relevant form instead of switching to a prominent error screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->