### PR TITLE
feat: improve host grouping and form saving

### DIFF
--- a/apps/bast/go.mod
+++ b/apps/bast/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/atotto/clipboard v0.1.4
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
 	golang.org/x/sync v0.22.0
 )
@@ -14,7 +15,6 @@ require (
 require (
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/apps/bast/internal/metadata/metadata.go
+++ b/apps/bast/internal/metadata/metadata.go
@@ -189,6 +189,32 @@ func (s *Store) SetHost(alias string, host Host) error {
 	return nil
 }
 
+// MoveHost updates a host's group and the collapsed-group preferences in one
+// state-file replacement so the UI cannot report a failed move after the host
+// change has already been persisted.
+func (s *Store) MoveHost(alias, group string, collapsedGroups []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	host, existed := s.state.Hosts[alias]
+	previousHost := host
+	previousPreferences := s.state.Preferences
+	host.Group = group
+	s.state.Hosts[alias] = host
+	s.state.Preferences.CollapsedGroups = cleanCollapsedGroups(collapsedGroups)
+	if err := s.save(); err != nil {
+		if existed {
+			s.state.Hosts[alias] = previousHost
+		} else {
+			delete(s.state.Hosts, alias)
+		}
+		s.state.Preferences = previousPreferences
+		return err
+	}
+	s.hostRevision.Add(1)
+	return nil
+}
+
 // UpdateHosts applies a related set of host metadata changes with one atomic
 // persistence operation. The callback must not call other Store methods.
 func (s *Store) UpdateHosts(update func(map[string]Host)) error {

--- a/apps/bast/internal/metadata/metadata_test.go
+++ b/apps/bast/internal/metadata/metadata_test.go
@@ -197,6 +197,9 @@ func TestFailedHostMutationRestoresStateAndRevision(t *testing.T) {
 		{name: "set", mutate: func(store *Store) error {
 			return store.SetHost("source", Host{Label: "changed"})
 		}},
+		{name: "move", mutate: func(store *Store) error {
+			return store.MoveHost("source", "Moved", []string{"Moved"})
+		}},
 		{name: "delete", mutate: func(store *Store) error {
 			return store.DeleteHost("source")
 		}},
@@ -230,6 +233,7 @@ func TestFailedHostMutationRestoresStateAndRevision(t *testing.T) {
 				t.Fatal(err)
 			}
 			beforeHosts, beforeRevision := store.HostsSnapshot()
+			beforePreferences := store.Preferences()
 			blockedPath := filepath.Join(root, "blocked")
 			if err := os.Mkdir(blockedPath, 0700); err != nil {
 				t.Fatal(err)
@@ -245,6 +249,9 @@ func TestFailedHostMutationRestoresStateAndRevision(t *testing.T) {
 			}
 			if afterRevision != beforeRevision {
 				t.Fatalf("revision changed after failed save: before=%d after=%d", beforeRevision, afterRevision)
+			}
+			if afterPreferences := store.Preferences(); !reflect.DeepEqual(afterPreferences, beforePreferences) {
+				t.Fatalf("preferences changed after failed save: before=%+v after=%+v", beforePreferences, afterPreferences)
 			}
 		})
 	}

--- a/apps/bast/internal/ui/app.go
+++ b/apps/bast/internal/ui/app.go
@@ -91,6 +91,8 @@ type processDoneMsg struct {
 
 type clearStatusMsg uint64
 
+type hostSaveHintTickMsg uint64
+
 type reportResultMsg struct {
 	err error
 }
@@ -156,6 +158,8 @@ type App struct {
 	status            string
 	statusError       bool
 	statusID          uint64
+	hostSaveHintID    uint64
+	hostSaveHintEnter bool
 	width             int
 	height            int
 	dark              bool
@@ -453,6 +457,12 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = ""
 		}
 		return m, nil
+	case hostSaveHintTickMsg:
+		if uint64(msg) != m.hostSaveHintID || m.form == nil || !isHostForm(m.form) {
+			return m, nil
+		}
+		m.hostSaveHintEnter = !m.hostSaveHintEnter
+		return m, m.hostSaveHintTickCmd()
 	case updateAvailableMsg:
 		m.latestVersion, m.updateSuggestion = msg.version, msg.suggestion
 		return m, nil
@@ -503,7 +513,11 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.form != nil {
 			return m.updateForm(msg)
 		}
-		return m.updateKeys(msg)
+		model, cmd := m.updateKeys(msg)
+		if m.form != nil && isHostForm(m.form) {
+			cmd = tea.Batch(cmd, m.hostSaveHintTickCmd())
+		}
+		return model, cmd
 	}
 	return m, nil
 }

--- a/apps/bast/internal/ui/app.go
+++ b/apps/bast/internal/ui/app.go
@@ -513,7 +513,7 @@ func (m *App) View() tea.View {
 	view := tea.NewView(content)
 	view.AltScreen = true
 	view.MouseMode = tea.MouseModeCellMotion
-	if m.form != nil {
+	if m.form != nil && !isHostForm(m.form) {
 		view.MouseMode = tea.MouseModeNone
 	}
 	view.WindowTitle = "Bast — SSH picker"

--- a/apps/bast/internal/ui/app_test.go
+++ b/apps/bast/internal/ui/app_test.go
@@ -18,6 +18,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	cloudsync "bast/internal/cloud/sync"
 	"bast/internal/connectbanner"
 	keymodel "bast/internal/keys"
 	"bast/internal/metadata"
@@ -717,6 +718,9 @@ func TestQuickGroupAssignmentSupportsExistingNewAndNoGroup(t *testing.T) {
 			}
 		}
 		m.collapsedGroups = map[string]bool{"Work": true, "Work/Production": true, "Work/Production/API": true}
+		if err := m.metadata.SetCollapsedGroups([]string{"Work", "Work/Production", "Work/Production/API"}); err != nil {
+			t.Fatal(err)
+		}
 		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 		if m.form != nil {
 			t.Fatal("existing group assignment did not close the picker")
@@ -727,6 +731,9 @@ func TestQuickGroupAssignmentSupportsExistingNewAndNoGroup(t *testing.T) {
 		}
 		if len(m.collapsedGroups) != 0 {
 			t.Fatalf("destination path stayed collapsed: %#v", m.collapsedGroups)
+		}
+		if got := m.metadata.Preferences().CollapsedGroups; len(got) != 0 {
+			t.Fatalf("persisted destination path stayed collapsed: %#v", got)
 		}
 		m.selectAfterLoad()
 		selected, ok := m.selectedHost()
@@ -834,6 +841,28 @@ func TestQuickGroupAssignmentSupportsExistingNewAndNoGroup(t *testing.T) {
 			t.Fatalf("invalid group did not stay in the picker: %#v", m.form)
 		}
 	})
+
+	t.Run("reserved cloud group", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("beta", metadata.Host{Group: "Google Cloud/project"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		for _, option := range m.form.fieldByLabel("Group").options {
+			if cloudsync.IsSyncedGroup(option.value) {
+				t.Fatalf("picker includes reserved cloud group %q", option.value)
+			}
+		}
+		m.updateFormPaste(tea.PasteMsg{Content: "Google Cloud/custom"})
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if m.form == nil || !strings.Contains(m.form.validationError, "read-only") {
+			t.Fatalf("reserved group did not stay in the picker: %#v", m.form)
+		}
+		if got := m.metadata.Host("alpha").Group; got != "" {
+			t.Fatalf("host moved into reserved group %q", got)
+		}
+	})
 }
 
 func TestGroupPickerRoutesPasteAndEscape(t *testing.T) {
@@ -937,6 +966,32 @@ func TestHostEditorSaveIsVisiblePortableAndClickable(t *testing.T) {
 			t.Fatal("unrelated form unexpectedly enabled mouse reporting")
 		}
 	})
+}
+
+func TestHostEditorSaveHintAlternatesWithoutStaleTicks(t *testing.T) {
+	m := testApp(t)
+	_, cmd := m.Update(press("a"))
+	if cmd == nil {
+		t.Fatal("opening the host editor did not schedule the save hint")
+	}
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Ctrl+J save") || strings.Contains(footer, "Ctrl+↵ save") {
+		t.Fatalf("initial save hint = %q", footer)
+	}
+
+	hintID := m.hostSaveHintID
+	_, cmd = m.Update(hostSaveHintTickMsg(hintID))
+	if cmd == nil {
+		t.Fatal("active host editor did not schedule the next save hint")
+	}
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Ctrl+↵ save") || strings.Contains(footer, "Ctrl+J save") {
+		t.Fatalf("alternate save hint = %q", footer)
+	}
+
+	m.form = nil
+	_, cmd = m.Update(hostSaveHintTickMsg(hintID))
+	if cmd != nil {
+		t.Fatal("closed host editor kept the save hint timer alive")
+	}
 }
 
 func TestMouseSelectsTabsAndListRowsOnly(t *testing.T) {

--- a/apps/bast/internal/ui/app_test.go
+++ b/apps/bast/internal/ui/app_test.go
@@ -45,6 +45,10 @@ func ctrlEnter() tea.KeyPressMsg {
 	return tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter, Text: "\x00", Mod: tea.ModCtrl})
 }
 
+func ctrlJ() tea.KeyPressMsg {
+	return tea.KeyPressMsg(tea.Key{Code: 'j', Mod: tea.ModCtrl})
+}
+
 func ctrlC() tea.KeyPressMsg {
 	return tea.KeyPressMsg(tea.Key{Code: 'c', Mod: tea.ModCtrl})
 }
@@ -90,6 +94,17 @@ func formFieldByLabel(m *App, label string) field {
 		return field{}
 	}
 	return *t
+}
+
+func selectHostAlias(t *testing.T, m *App, alias string) {
+	t.Helper()
+	for i, row := range m.hostListRows() {
+		if !row.header && row.suggestion == nil && row.host.Alias == alias {
+			m.cursor = i
+			return
+		}
+	}
+	t.Fatalf("host %q not found", alias)
 }
 
 func TestNumberedNavigationAndSearch(t *testing.T) {
@@ -669,6 +684,261 @@ func TestGroupPathsAreNormalizedAndLimitedToFiveLevels(t *testing.T) {
 	}
 }
 
+func TestQuickGroupAssignmentSupportsExistingNewAndNoGroup(t *testing.T) {
+	t.Run("fuzzy existing ancestor", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("alpha", metadata.Host{Notes: "keep"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.metadata.SetHost("beta", metadata.Host{Group: "Work/Production/API"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.metadata.SetHost("removed", metadata.Host{Group: "Removed/Phantom"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.Update(press("m"))
+		if m.form == nil || m.form.action != "group_assign" || !m.form.input.Focused() {
+			t.Fatalf("m did not open a focused searchable group picker: %#v", m.form)
+		}
+		if rendered := m.renderGroupAssignmentForm(m.styles()); !strings.Contains(rendered, "No group") || !strings.Contains(rendered, "Current: No group") {
+			t.Fatalf("initial picker is incorrect:\n%s", rendered)
+		}
+		for _, key := range []string{"w", "p", "a"} {
+			m.Update(press(key))
+		}
+		choices := m.groupPickerChoices()
+		if len(choices) < 2 || choices[0].value != "Work/Production/API" || !choices[1].create {
+			t.Fatalf("fuzzy choices for wpa = %#v", choices)
+		}
+		for _, choice := range choices {
+			if choice.value == "Removed/Phantom" {
+				t.Fatalf("picker includes metadata for an absent host: %#v", choices)
+			}
+		}
+		m.collapsedGroups = map[string]bool{"Work": true, "Work/Production": true, "Work/Production/API": true}
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if m.form != nil {
+			t.Fatal("existing group assignment did not close the picker")
+		}
+		got := m.metadata.Host("alpha")
+		if got.Group != "Work/Production/API" || got.Notes != "keep" {
+			t.Fatalf("metadata after assignment = %#v", got)
+		}
+		if len(m.collapsedGroups) != 0 {
+			t.Fatalf("destination path stayed collapsed: %#v", m.collapsedGroups)
+		}
+		m.selectAfterLoad()
+		selected, ok := m.selectedHost()
+		if !ok || selected.Alias != "alpha" {
+			t.Fatalf("selected host after assignment = %#v, ok=%t", selected, ok)
+		}
+	})
+
+	t.Run("current group selected", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("alpha", metadata.Host{Group: "Work/Production/API"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		group := m.form.fieldByLabel("Group")
+		choices := m.groupPickerChoices()
+		if got := choices[group.selected].value; got != "Work/Production/API" {
+			t.Fatalf("selected group = %q", got)
+		}
+		m.updateForm(press("x"))
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
+		choices = m.groupPickerChoices()
+		if got := choices[group.selected].value; got != "Work/Production/API" {
+			t.Fatalf("selected group after clearing search = %q", got)
+		}
+	})
+
+	t.Run("new normalized path", func(t *testing.T) {
+		m := testApp(t)
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		m.updateFormPaste(tea.PasteMsg{Content: "Team / Platform"})
+		choices := m.groupPickerChoices()
+		if len(choices) != 1 || !choices[0].create {
+			t.Fatalf("new-path choices = %#v", choices)
+		}
+		if rendered := m.renderGroupAssignmentForm(m.styles()); !strings.Contains(rendered, `Create "Team / Platform"`) {
+			t.Fatalf("picker does not offer creation:\n%s", rendered)
+		}
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if got := m.metadata.Host("alpha").Group; got != "Team/Platform" {
+			t.Fatalf("new group = %q", got)
+		}
+	})
+
+	t.Run("normalized exact match", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("beta", metadata.Host{Group: "Work/Production"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		m.updateFormPaste(tea.PasteMsg{Content: "Work / Production"})
+		choices := m.groupPickerChoices()
+		if len(choices) != 1 || choices[0].value != "Work/Production" || choices[0].create {
+			t.Fatalf("normalized exact choices = %#v", choices)
+		}
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if got := m.metadata.Host("alpha").Group; got != "Work/Production" {
+			t.Fatalf("matched group = %q", got)
+		}
+	})
+
+	t.Run("custom alongside fuzzy match", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("beta", metadata.Host{Group: "Work/Production"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		m.updateFormPaste(tea.PasteMsg{Content: "prod"})
+		choices := m.groupPickerChoices()
+		if len(choices) < 2 || choices[0].value != "Work/Production" || !choices[1].create {
+			t.Fatalf("pick/create choices = %#v", choices)
+		}
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyDown}))
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if got := m.metadata.Host("alpha").Group; got != "prod" {
+			t.Fatalf("custom group = %q", got)
+		}
+	})
+
+	t.Run("no group", func(t *testing.T) {
+		m := testApp(t)
+		if err := m.metadata.SetHost("alpha", metadata.Host{Group: "Work"}); err != nil {
+			t.Fatal(err)
+		}
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyUp}))
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if got := m.metadata.Host("alpha").Group; got != "" {
+			t.Fatalf("cleared group = %q", got)
+		}
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		m := testApp(t)
+		selectHostAlias(t, m, "alpha")
+		m.updateKeys(press("m"))
+		m.updateFormPaste(tea.PasteMsg{Content: "one/two/three/four/five/six"})
+		m.updateForm(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+		if m.form == nil || !strings.Contains(m.form.validationError, "at most 5") {
+			t.Fatalf("invalid group did not stay in the picker: %#v", m.form)
+		}
+	})
+}
+
+func TestGroupPickerRoutesPasteAndEscape(t *testing.T) {
+	m := testApp(t)
+	selectHostAlias(t, m, "alpha")
+	m.Update(press("m"))
+	m.Update(tea.PasteMsg{Content: "Team/Platform"})
+	if m.form == nil || m.form.input.Value() != "Team/Platform" {
+		t.Fatalf("paste was not routed to group search: %#v", m.form)
+	}
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if m.form != nil {
+		t.Fatal("Esc did not cancel the group picker")
+	}
+}
+
+func TestFuzzyGroupScoreUsesBestAlignment(t *testing.T) {
+	short, shortOK := fuzzyGroupScore("P/Prod", "prod")
+	long, longOK := fuzzyGroupScore("X/ProdLong", "prod")
+	if !shortOK || !longOK || short <= long {
+		t.Fatalf("fuzzy scores: P/Prod=%d (%t), X/ProdLong=%d (%t)", short, shortOK, long, longOK)
+	}
+}
+
+func TestQuickGroupAssignmentRejectsSyncedHosts(t *testing.T) {
+	m := testApp(t)
+	m.hosts = []sshconfig.Host{{Alias: "cloud", Synced: true}}
+	selectHostAlias(t, m, "cloud")
+	m.updateKeys(press("m"))
+	if m.form != nil || !m.statusError || !strings.Contains(m.status, "read-only") {
+		t.Fatalf("synced assignment: form=%#v status=%q", m.form, m.status)
+	}
+}
+
+func TestHostEditorSaveIsVisiblePortableAndClickable(t *testing.T) {
+	t.Run("Ctrl+J", func(t *testing.T) {
+		m := testApp(t)
+		m.openEditHostForm()
+		m.form.input.SetValue("Portable label")
+		m.updateForm(ctrlJ())
+		if m.form != nil {
+			t.Fatal("Ctrl+J did not save the host form")
+		}
+		if got := m.metadata.Host("alpha").Label; got != "Portable label" {
+			t.Fatalf("saved label = %q", got)
+		}
+	})
+
+	t.Run("click", func(t *testing.T) {
+		m := testApp(t)
+		m.openEditHostForm()
+		if view := m.renderHostForm(m.styles()); !strings.Contains(view, m.styles().title.Render(hostFormSaveButtonLabel)) {
+			t.Fatalf("host form has no Connect-style Save target:\n%s", view)
+		}
+		if m.View().MouseMode != tea.MouseModeCellMotion {
+			t.Fatal("host form did not enable mouse reporting")
+		}
+		x, y, width := m.hostFormSaveButtonBounds()
+		lines := strings.Split(m.render(), "\n")
+		if y >= len(lines) || !strings.Contains(lines[y], hostFormSaveButtonLabel) {
+			t.Fatalf("Save bounds row %d does not contain the button", y)
+		}
+		buttonOffset := strings.Index(lines[y], hostFormSaveButtonLabel)
+		if got := lipgloss.Width(lines[y][:buttonOffset]); got != x {
+			t.Fatalf("Save bounds x = %d, rendered x = %d", x, got)
+		}
+		m.form.input.SetValue("Clicked label")
+		m.Update(tea.MouseClickMsg(tea.Mouse{X: x + width/2, Y: y, Button: tea.MouseLeft}))
+		if m.form != nil {
+			t.Fatal("clicking Save did not close the host form")
+		}
+		if got := m.metadata.Host("alpha").Label; got != "Clicked label" {
+			t.Fatalf("saved label = %q", got)
+		}
+	})
+
+	t.Run("wide title", func(t *testing.T) {
+		m := testApp(t)
+		m.width = 30
+		if err := m.metadata.SetHost("alpha", metadata.Host{Label: "生产服务器"}); err != nil {
+			t.Fatal(err)
+		}
+		m.openEditHostForm()
+		x, y, width := m.hostFormSaveButtonBounds()
+		lines := strings.Split(m.render(), "\n")
+		buttonOffset := strings.Index(lines[y], hostFormSaveButtonLabel)
+		if buttonOffset < 0 || lipgloss.Width(lines[y][:buttonOffset]) != x {
+			t.Fatalf("wide title shifted Save away from x=%d: %q", x, lines[y])
+		}
+		m.Update(tea.MouseClickMsg(tea.Mouse{X: x + width/2, Y: y, Button: tea.MouseLeft}))
+		if m.form != nil {
+			t.Fatal("clicking Save with a wide title did not close the form")
+		}
+	})
+
+	t.Run("unrelated form", func(t *testing.T) {
+		m := testApp(t)
+		m.hosts[0].Managed = true
+		m.openDeleteHostForm()
+		if m.View().MouseMode != tea.MouseModeNone {
+			t.Fatal("unrelated form unexpectedly enabled mouse reporting")
+		}
+	})
+}
+
 func TestMouseSelectsTabsAndListRowsOnly(t *testing.T) {
 	m := testApp(t)
 	if m.View().MouseMode != tea.MouseModeCellMotion {
@@ -710,7 +980,7 @@ func TestExternalHostEditOnlyOffersMetadataAndIsFullyRevealed(t *testing.T) {
 		t.Fatalf("metadata section was not opened:\n%s", rendered)
 	}
 	footer := m.renderFooter(m.styles())
-	if !strings.Contains(footer, "Ctrl+Enter save") || strings.Contains(footer, "connect") {
+	if !strings.Contains(footer, "Ctrl+J save") || strings.Contains(footer, "connect") {
 		t.Fatalf("metadata editor footer is incorrect: %q", footer)
 	}
 }
@@ -718,12 +988,12 @@ func TestExternalHostEditOnlyOffersMetadataAndIsFullyRevealed(t *testing.T) {
 func TestFooterShowsControlsForTheActiveFormState(t *testing.T) {
 	m := testApp(t)
 	m.openAddHostForm()
-	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Enter next") || !strings.Contains(footer, "Ctrl+Enter save") || !strings.Contains(footer, "Esc cancel") || strings.Contains(footer, "connect") {
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Enter next") || !strings.Contains(footer, "Ctrl+J save") || !strings.Contains(footer, "Esc cancel") || strings.Contains(footer, "connect") {
 		t.Fatalf("create footer = %q", footer)
 	}
 
 	m.openEditHostForm()
-	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Ctrl+Enter save") || !strings.Contains(footer, "Tab move") || strings.Contains(footer, "connect") {
+	if footer := m.renderFooter(m.styles()); !strings.Contains(footer, "Ctrl+J save") || !strings.Contains(footer, "Tab move") || strings.Contains(footer, "connect") {
 		t.Fatalf("edit footer = %q", footer)
 	}
 	enterHostFormSection(t, m, formSectionMetadata)

--- a/apps/bast/internal/ui/forms.go
+++ b/apps/bast/internal/ui/forms.go
@@ -347,13 +347,16 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 		if err != nil {
 			return m.formValidationError(err.Error())
 		}
-		host := m.metadata.Host(alias)
-		host.Group = group
-		err = m.metadata.SetHost(alias, host)
-		if err == nil {
-			err = m.revealGroup(group)
+		if sync.IsSyncedGroup(group) {
+			return m.formValidationError("cloud sync groups are read-only")
 		}
+		collapsedGroups, collapsedPaths, collapseChanged := m.collapsedGroupsRevealing(group)
+		err = m.metadata.MoveHost(alias, group, collapsedPaths)
 		if err == nil {
+			m.collapsedGroups = collapsedGroups
+			if collapseChanged {
+				m.collapseRevision++
+			}
 			m.selectAfterLoadSection, m.selectAfterLoadName, m.selectAfterLoadGroup = hostsSection, alias, false
 		}
 		return m.finishMutation(err, "Host group saved")
@@ -596,7 +599,9 @@ func (m *App) groupAssignmentField(current string) field {
 			} else {
 				path += "/" + part
 			}
-			paths[path] = true
+			if !sync.IsSyncedGroup(path) {
+				paths[path] = true
+			}
 		}
 	}
 	ordered := make([]string, 0, len(paths))

--- a/apps/bast/internal/ui/forms.go
+++ b/apps/bast/internal/ui/forms.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
@@ -52,6 +53,9 @@ func (m *App) formTextInputActive() bool {
 	if f == nil {
 		return false
 	}
+	if isGroupAssignmentForm(f) {
+		return true
+	}
 	if isHostForm(f) {
 		if f.selecting {
 			return false
@@ -93,6 +97,9 @@ func (m *App) updateFormQuit(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
 func (m *App) updateForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if model, cmd, quit := m.updateFormQuit(msg); quit {
 		return model, cmd
+	}
+	if isGroupAssignmentForm(m.form) {
+		return m.updateGroupAssignmentForm(msg)
 	}
 	if isHostForm(m.form) {
 		return m.updateHostForm(msg)
@@ -207,6 +214,9 @@ func isEditForm(f *form) bool {
 
 func (m *App) updateFormPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	f := m.form
+	if isGroupAssignmentForm(f) {
+		return m.updateGroupAssignmentInput(msg)
+	}
 	f.validationError = ""
 	content := strings.TrimSpace(msg.Content)
 	if f.action == "key_import" && f.fields[f.index].label == "Private key" && strings.Contains(content, "PRIVATE KEY-----") {
@@ -331,6 +341,22 @@ func (m *App) submitForm() (tea.Model, tea.Cmd) {
 			m.selectAfterLoadSection, m.selectAfterLoadName, m.selectAfterLoadGroup = hostsSection, group, true
 		}
 		return m.finishMutation(err, "Host metadata saved")
+	case "group_assign":
+		alias := values["Alias"]
+		group, err := metadata.NormalizeGroupPath(values["Group"])
+		if err != nil {
+			return m.formValidationError(err.Error())
+		}
+		host := m.metadata.Host(alias)
+		host.Group = group
+		err = m.metadata.SetHost(alias, host)
+		if err == nil {
+			err = m.revealGroup(group)
+		}
+		if err == nil {
+			m.selectAfterLoadSection, m.selectAfterLoadName, m.selectAfterLoadGroup = hostsSection, alias, false
+		}
+		return m.finishMutation(err, "Host group saved")
 	case "host_delete":
 		alias := values["Alias"]
 		if values["Type the name to confirm"] != values["Confirmation"] {
@@ -535,6 +561,69 @@ func (m *App) openEditHostForm() {
 		passwordOnly:      isPasswordOnly,
 		advanced:          adv,
 	}, []field{{label: "Original label", value: host.Alias, hidden: true}}))
+}
+
+func (m *App) openGroupAssignmentForm() {
+	host, ok := m.selectedHost()
+	if !ok {
+		return
+	}
+	if host.Synced {
+		m.status, m.statusError = "Synced hosts are read-only; manage them in the Sync tab", true
+		return
+	}
+	meta := m.metadata.Host(host.Alias)
+	m.openForm("Move host — "+m.hostLabel(host), "group_assign", []field{
+		{label: "Alias", value: host.Alias, hidden: true},
+		{label: "Current group", value: meta.Group, hidden: true},
+		m.groupAssignmentField(meta.Group),
+	})
+	m.form.selecting = false
+	m.form.input.SetValue("")
+	m.form.input.Placeholder = "Search or create a group"
+	m.form.input.Focus()
+}
+
+func (m *App) groupAssignmentField(current string) field {
+	paths := map[string]bool{}
+	metadataByHost := m.hostMetadata()
+	for _, host := range m.hosts {
+		parts := groupPathParts(metadataByHost[host.Alias].Group)
+		path := ""
+		for _, part := range parts {
+			if path == "" {
+				path = part
+			} else {
+				path += "/" + part
+			}
+			paths[path] = true
+		}
+	}
+	ordered := make([]string, 0, len(paths))
+	for path := range paths {
+		ordered = append(ordered, path)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		left, right := strings.ToLower(ordered[i]), strings.ToLower(ordered[j])
+		if left == right {
+			return ordered[i] < ordered[j]
+		}
+		return left < right
+	})
+
+	item := field{
+		label:       "Group",
+		description: "Choose an existing group, clear the group, or enter a new path",
+		placeholder: "Work/Production",
+		options:     []fieldOption{{label: "No group"}},
+	}
+	for _, path := range ordered {
+		item.options = append(item.options, fieldOption{label: path, value: path})
+		if path == current {
+			item.selected = len(item.options) - 1
+		}
+	}
+	return item
 }
 
 func (m *App) openDeleteHostForm() {

--- a/apps/bast/internal/ui/group_form.go
+++ b/apps/bast/internal/ui/group_form.go
@@ -1,0 +1,272 @@
+package ui
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"bast/internal/metadata"
+)
+
+type groupPickerChoice struct {
+	label  string
+	value  string
+	create bool
+	score  int
+}
+
+func isGroupAssignmentForm(f *form) bool {
+	return f != nil && f.action == "group_assign"
+}
+
+func (m *App) updateGroupAssignmentForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	f := m.form
+	choices := m.groupPickerChoices()
+	key := msg.String()
+	switch key {
+	case "esc":
+		m.form = nil
+		return m, nil
+	case "up", "shift+tab", "down", "tab":
+		if len(choices) > 0 {
+			direction := 1
+			if key == "up" || key == "shift+tab" {
+				direction = -1
+			}
+			item := &f.fields[f.index]
+			item.selected = (item.selected + direction + len(choices)) % len(choices)
+		}
+		return m, nil
+	case "enter":
+		if len(choices) == 0 {
+			return m, nil
+		}
+		selected := min(f.fields[f.index].selected, len(choices)-1)
+		f.fields[f.index].value = choices[selected].value
+		return m.submitForm()
+	}
+
+	return m.updateGroupAssignmentInput(msg)
+}
+
+func (m *App) updateGroupAssignmentInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	f := m.form
+	before := f.input.Value()
+	var cmd tea.Cmd
+	f.input, cmd = f.input.Update(msg)
+	if f.input.Value() == before {
+		return m, cmd
+	}
+	m.resetGroupPickerSelection()
+	f.validationError = ""
+	return m, cmd
+}
+
+func (m *App) groupPickerChoices() []groupPickerChoice {
+	f := m.form
+	item := f.fieldByLabel("Group")
+	if item == nil {
+		return nil
+	}
+	query := strings.TrimSpace(f.input.Value())
+	if query == "" {
+		choices := make([]groupPickerChoice, 0, len(item.options))
+		for _, option := range item.options {
+			choices = append(choices, groupPickerChoice{label: option.label, value: option.value})
+		}
+		return choices
+	}
+
+	normalized, err := metadata.NormalizeGroupPath(query)
+	matchQuery := query
+	if err == nil {
+		matchQuery = normalized
+	}
+
+	choices := make([]groupPickerChoice, 0, len(item.options)+1)
+	exact := false
+	for _, option := range item.options {
+		if option.value == "" {
+			continue
+		}
+		if err == nil && strings.EqualFold(option.value, normalized) {
+			exact = true
+		}
+		score, ok := fuzzyGroupScore(option.value, matchQuery)
+		if ok {
+			choices = append(choices, groupPickerChoice{label: option.label, value: option.value, score: score})
+		}
+	}
+	sort.SliceStable(choices, func(i, j int) bool {
+		left, right := choices[i], choices[j]
+		if left.score != right.score {
+			return left.score > right.score
+		}
+		leftLength, rightLength := len([]rune(left.value)), len([]rune(right.value))
+		if leftLength != rightLength {
+			return leftLength < rightLength
+		}
+		return strings.ToLower(left.value) < strings.ToLower(right.value)
+	})
+
+	if !exact {
+		create := groupPickerChoice{
+			label:  fmt.Sprintf("Create %q", query),
+			value:  query,
+			create: true,
+		}
+		choices = slices.Insert(choices, min(1, len(choices)), create)
+	}
+	return choices
+}
+
+func (m *App) resetGroupPickerSelection() {
+	item := m.form.fieldByLabel("Group")
+	if item == nil {
+		return
+	}
+	item.selected = 0
+	if strings.TrimSpace(m.form.input.Value()) != "" {
+		return
+	}
+	current := groupAssignmentCurrentGroup(m.form)
+	for i, option := range item.options {
+		if option.value == current {
+			item.selected = i
+			return
+		}
+	}
+}
+
+func groupAssignmentCurrentGroup(f *form) string {
+	if field := f.fieldByLabel("Current group"); field != nil {
+		return field.value
+	}
+	return ""
+}
+
+func fuzzyGroupScore(candidate, query string) (int, bool) {
+	candidateLower := strings.ToLower(candidate)
+	queryLower := strings.ToLower(strings.TrimSpace(query))
+	candidateRunes := []rune(candidateLower)
+	queryRunes := []rune(queryLower)
+	if len(queryRunes) == 0 {
+		return 0, true
+	}
+
+	const (
+		noMatch            = -1 << 30
+		baseMatchScore     = 10
+		groupBoundaryBonus = 12
+		consecutiveBonus   = 8
+		exactMatchBonus    = 300
+		prefixMatchBonus   = 150
+		substringBonus     = 100
+	)
+	previousScores := make([]int, len(candidateRunes))
+	for i := range previousScores {
+		previousScores[i] = noMatch
+	}
+	for queryIndex, wanted := range queryRunes {
+		currentScores := make([]int, len(candidateRunes))
+		for i := range currentScores {
+			currentScores[i] = noMatch
+		}
+		matched := false
+		for candidateIndex, candidateRune := range candidateRunes {
+			if candidateRune != wanted {
+				continue
+			}
+			matchScore := baseMatchScore
+			if candidateIndex == 0 || candidateRunes[candidateIndex-1] == '/' || candidateRunes[candidateIndex-1] == ' ' || candidateRunes[candidateIndex-1] == '-' {
+				matchScore += groupBoundaryBonus
+			}
+			if queryIndex == 0 {
+				currentScores[candidateIndex] = matchScore - candidateIndex
+				matched = true
+				continue
+			}
+			for previousIndex := 0; previousIndex < candidateIndex; previousIndex++ {
+				if previousScores[previousIndex] == noMatch {
+					continue
+				}
+				score := previousScores[previousIndex] + matchScore - (candidateIndex - previousIndex - 1)
+				if candidateIndex == previousIndex+1 {
+					score += consecutiveBonus
+				}
+				currentScores[candidateIndex] = max(currentScores[candidateIndex], score)
+			}
+			matched = matched || currentScores[candidateIndex] != noMatch
+		}
+		if !matched {
+			return 0, false
+		}
+		previousScores = currentScores
+	}
+
+	bestScore := noMatch
+	for _, score := range previousScores {
+		bestScore = max(bestScore, score)
+	}
+	switch {
+	case candidateLower == queryLower:
+		bestScore += exactMatchBonus
+	case strings.HasPrefix(candidateLower, queryLower):
+		bestScore += prefixMatchBonus
+	case strings.Contains(candidateLower, queryLower):
+		bestScore += substringBonus
+	}
+	bestScore -= len(candidateRunes) - len(queryRunes)
+	return bestScore, true
+}
+
+func (m *App) renderGroupAssignmentForm(s styleSet) string {
+	f := m.form
+	item := f.fieldByLabel("Group")
+	choices := m.groupPickerChoices()
+	if item.selected >= len(choices) {
+		item.selected = max(0, len(choices)-1)
+	}
+
+	var b strings.Builder
+	b.WriteString("\n  " + s.active.Render(f.title) + "\n\n")
+	b.WriteString("  " + s.active.Render("› Group") + "\n")
+	b.WriteString("    " + s.muted.Render("Search existing groups or type a new path") + "\n")
+	b.WriteString("    " + f.input.View() + "\n")
+
+	current := groupAssignmentCurrentGroup(f)
+	currentLabel := current
+	if currentLabel == "" {
+		currentLabel = "No group"
+	}
+	b.WriteString("    " + s.muted.Render("Current: "+currentLabel) + "\n\n")
+
+	rows := min(7, len(choices))
+	start := scrollStart(item.selected, len(choices), rows)
+	for i := start; i < min(len(choices), start+rows); i++ {
+		choice := choices[i]
+		label := choice.label
+		if choice.value == current && !choice.create {
+			label += "  current"
+		}
+		if choice.create {
+			label = "+ " + label
+		}
+		if i == item.selected {
+			b.WriteString("    " + s.selected.Render("› "+label) + "\n")
+		} else {
+			b.WriteString("    " + s.muted.Render("  "+label) + "\n")
+		}
+	}
+	if f.validationError != "" {
+		b.WriteString("\n    " + s.error.Render("✕ "+f.validationError) + "\n")
+	}
+	return b.String()
+}
+
+func groupAssignmentHint() string {
+	return "Type to filter • ↑/↓ choose • Enter assign/create • Esc cancel"
+}

--- a/apps/bast/internal/ui/host_form.go
+++ b/apps/bast/internal/ui/host_form.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
@@ -18,6 +19,7 @@ const (
 	formSectionAdvanced     = "advanced"
 	formSectionMetadata     = "metadata"
 	hostFormSaveButtonLabel = " Save "
+	hostSaveHintInterval    = 2 * time.Second
 )
 
 type hostHubItem struct {
@@ -214,7 +216,16 @@ func (m *App) openHostForm(title, action string, fields []field) {
 		title: title, action: action, fields: fields, input: input,
 		screen: "hub", hubIndex: 0,
 	}
+	m.hostSaveHintID++
+	m.hostSaveHintEnter = false
 	m.focusHostHubItem()
+}
+
+func (m *App) hostSaveHintTickCmd() tea.Cmd {
+	hintID := m.hostSaveHintID
+	return tea.Tick(hostSaveHintInterval, func(time.Time) tea.Msg {
+		return hostSaveHintTickMsg(hintID)
+	})
 }
 
 func (m *App) focusHostHubItem() {
@@ -734,9 +745,13 @@ func (m *App) renderHostSectionForm(s styleSet) string {
 	return b.String()
 }
 
-func hostFormHint(f *form, textInputActive bool) string {
+func hostFormHint(f *form, textInputActive, showEnterKey bool) string {
+	save := "Ctrl+J save"
+	if showEnterKey {
+		save = "Ctrl+↵ save"
+	}
 	if f.screen == formScreenAdvancedHub {
-		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • Ctrl+J save • q quit"
+		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • " + save + " • q quit"
 	}
 	if f.screen != "" && f.screen != "hub" {
 		if f.selecting {
@@ -748,23 +763,23 @@ func hostFormHint(f *form, textInputActive bool) string {
 			action = "Enter change"
 		}
 		if len(item.options) > 0 && item.options[item.selected].custom {
-			return action + " • Esc choices • ⌫ edit • Ctrl+J save"
+			return action + " • Esc choices • ⌫ edit • " + save
 		}
 		hint := action + " • ↑/↓ or Tab move • ⌫/Esc back"
 		if !textInputActive {
 			hint += " • q quit"
 		}
-		return hint + " • Ctrl+J save"
+		return hint + " • " + save
 	}
 
 	items := hostHubItems(f)
 	if f.hubIndex >= 0 && f.hubIndex < len(items) {
 		hub := items[f.hubIndex]
 		if hub.id == "label" || hub.id == "hostname" {
-			return "Enter next • ↑/↓ or Tab move • Ctrl+J save • q type • Esc cancel"
+			return "Enter next • ↑/↓ or Tab move • " + save + " • q type • Esc cancel"
 		}
 	}
-	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫/Esc cancel • Ctrl+J save • q quit"
+	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫/Esc cancel • " + save + " • q quit"
 }
 
 func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, hidden []field) []field {

--- a/apps/bast/internal/ui/host_form.go
+++ b/apps/bast/internal/ui/host_form.go
@@ -6,16 +6,18 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"bast/internal/metadata"
 	"bast/internal/sshconfig"
 )
 
 const (
-	formSectionBasics   = "basics"
-	formSectionAuth     = "auth"
-	formSectionAdvanced = "advanced"
-	formSectionMetadata = "metadata"
+	formSectionBasics       = "basics"
+	formSectionAuth         = "auth"
+	formSectionAdvanced     = "advanced"
+	formSectionMetadata     = "metadata"
+	hostFormSaveButtonLabel = " Save "
 )
 
 type hostHubItem struct {
@@ -31,6 +33,42 @@ func isHostForm(f *form) bool {
 	default:
 		return false
 	}
+}
+
+func (m *App) hostFormSaveButtonBounds() (x, y, width int) {
+	width = lipgloss.Width(hostFormSaveButtonLabel)
+	x = max(2, m.terminalWidth()-2-width)
+	s := m.styles()
+	header := m.renderHeader(s) + "\n" + m.renderHeaderRule(s)
+	y = lipgloss.Height(lipgloss.NewStyle().Width(m.terminalWidth()).Render(header)) + 1
+	return x, y, width
+}
+
+func (m *App) renderHostFormHeader(s styleSet, breadcrumb string) string {
+	x, _, _ := m.hostFormSaveButtonBounds()
+	text := m.form.title
+	if breadcrumb != "" {
+		text += "  " + breadcrumb
+	}
+	available := max(0, x-3)
+	if available == 0 {
+		text = ""
+	} else {
+		text = ansi.Truncate(text, available, "…")
+	}
+
+	var b strings.Builder
+	b.WriteString("\n  ")
+	if text != "" {
+		b.WriteString(s.active.Render(text))
+	}
+	currentX := 2 + lipgloss.Width(text)
+	if currentX < x {
+		b.WriteString(strings.Repeat(" ", x-currentX))
+	}
+	b.WriteString(s.title.Render(hostFormSaveButtonLabel))
+	b.WriteString("\n\n")
+	return b.String()
 }
 
 func (f *form) fieldByLabel(label string) *field {
@@ -504,7 +542,7 @@ func (m *App) renderHostHubForm(s styleSet) string {
 	f := m.form
 	items := hostHubItems(f)
 	var b strings.Builder
-	b.WriteString("\n  " + s.active.Render(f.title) + "\n\n")
+	b.WriteString(m.renderHostFormHeader(s, ""))
 	b.WriteString("  " + s.active.Render("Basics") + "\n")
 	for _, hub := range items {
 		if hub.section == formSectionBasics {
@@ -640,7 +678,7 @@ func (m *App) renderHostSectionForm(s styleSet) string {
 		sectionTitle, breadcrumb = "Metadata", "› Metadata"
 	}
 	var b strings.Builder
-	b.WriteString("\n  " + s.active.Render(f.title) + "  " + s.muted.Render(breadcrumb) + "\n\n")
+	b.WriteString(m.renderHostFormHeader(s, breadcrumb))
 
 	indices := f.sectionFieldIndices(f.screen)
 	for _, idx := range indices {
@@ -698,7 +736,7 @@ func (m *App) renderHostSectionForm(s styleSet) string {
 
 func hostFormHint(f *form, textInputActive bool) string {
 	if f.screen == formScreenAdvancedHub {
-		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • Ctrl+Enter save • q quit"
+		return "Enter open section • ↑/↓ or j/k move • ⌫/Esc back • Ctrl+J save • q quit"
 	}
 	if f.screen != "" && f.screen != "hub" {
 		if f.selecting {
@@ -710,23 +748,23 @@ func hostFormHint(f *form, textInputActive bool) string {
 			action = "Enter change"
 		}
 		if len(item.options) > 0 && item.options[item.selected].custom {
-			return action + " • Esc choices • ⌫ edit • Ctrl+Enter save"
+			return action + " • Esc choices • ⌫ edit • Ctrl+J save"
 		}
 		hint := action + " • ↑/↓ or Tab move • ⌫/Esc back"
 		if !textInputActive {
 			hint += " • q quit"
 		}
-		return hint + " • Ctrl+Enter save"
+		return hint + " • Ctrl+J save"
 	}
 
 	items := hostHubItems(f)
 	if f.hubIndex >= 0 && f.hubIndex < len(items) {
 		hub := items[f.hubIndex]
 		if hub.id == "label" || hub.id == "hostname" {
-			return "Enter next • ↑/↓ or Tab move • Ctrl+Enter save • q type • Esc cancel"
+			return "Enter next • ↑/↓ or Tab move • Ctrl+J save • q type • Esc cancel"
 		}
 	}
-	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫/Esc cancel • Ctrl+Enter save • q quit"
+	return "Enter open section • ↑/↓ or j/k move • Tab next • ⌫/Esc cancel • Ctrl+J save • q quit"
 }
 
 func hostFormFields(m *App, meta metadataHostValues, conn hostConnectionValues, hidden []field) []field {

--- a/apps/bast/internal/ui/host_form_advanced.go
+++ b/apps/bast/internal/ui/host_form_advanced.go
@@ -194,7 +194,7 @@ func (m *App) updateAdvancedHubForm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m *App) renderAdvancedHubForm(s styleSet) string {
 	f := m.form
 	var b strings.Builder
-	b.WriteString("\n  " + s.active.Render(f.title) + "  " + s.muted.Render("› Advanced") + "\n\n")
+	b.WriteString(m.renderHostFormHeader(s, "› Advanced"))
 	for i, item := range advancedHubList {
 		summary := m.advancedSubsectionSummary(item.section)
 		line := item.title + "  " + summary

--- a/apps/bast/internal/ui/input.go
+++ b/apps/bast/internal/ui/input.go
@@ -76,10 +76,20 @@ func (c *connectionProcess) SetStderr(output io.Writer) {
 
 func (m *App) updateMouse(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	mouse := msg.Mouse()
-	if mouse.Button != tea.MouseLeft || m.help || m.credits || m.form != nil {
+	if mouse.Button != tea.MouseLeft || m.help || m.credits || (m.statusError && m.status != "") {
 		return m, nil
 	}
 	m.scrollbarDragging = false
+	if m.form != nil {
+		if isHostForm(m.form) {
+			x, y, width := m.hostFormSaveButtonBounds()
+			if mouse.Y == y && mouse.X >= x && mouse.X < x+width {
+				m.commitFormField()
+				return m.submitForm()
+			}
+		}
+		return m, nil
+	}
 
 	if mouse.Y == 0 {
 		tabsStart := lipgloss.Width(headerTitle) + 2
@@ -383,6 +393,10 @@ func (m *App) updateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 		} else {
 			m.openEditKeyForm()
+		}
+	case "m":
+		if m.section == hostsSection {
+			m.openGroupAssignmentForm()
 		}
 	case "d":
 		if m.section == syncSection {

--- a/apps/bast/internal/ui/state.go
+++ b/apps/bast/internal/ui/state.go
@@ -597,6 +597,31 @@ func (m *App) expandAllGroups() tea.Cmd {
 	return nil
 }
 
+func (m *App) revealGroup(group string) error {
+	if m.collapsedGroups == nil {
+		return nil
+	}
+	parts := groupPathParts(group)
+	path := ""
+	changed := false
+	for _, part := range parts {
+		if path == "" {
+			path = part
+		} else {
+			path += "/" + part
+		}
+		if m.collapsedGroups[path] {
+			delete(m.collapsedGroups, path)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	m.collapseRevision++
+	return m.persistCollapsedGroups()
+}
+
 func (m *App) persistCollapsedGroups() error {
 	live := map[string]bool{}
 	metadataByHost := m.hostMetadata()

--- a/apps/bast/internal/ui/state.go
+++ b/apps/bast/internal/ui/state.go
@@ -597,9 +597,10 @@ func (m *App) expandAllGroups() tea.Cmd {
 	return nil
 }
 
-func (m *App) revealGroup(group string) error {
-	if m.collapsedGroups == nil {
-		return nil
+func (m *App) collapsedGroupsRevealing(group string) (map[string]bool, []string, bool) {
+	next := make(map[string]bool, len(m.collapsedGroups))
+	for path, collapsed := range m.collapsedGroups {
+		next[path] = collapsed
 	}
 	parts := groupPathParts(group)
 	path := ""
@@ -610,16 +611,18 @@ func (m *App) revealGroup(group string) error {
 		} else {
 			path += "/" + part
 		}
-		if m.collapsedGroups[path] {
-			delete(m.collapsedGroups, path)
+		if next[path] {
+			delete(next, path)
 			changed = true
 		}
 	}
-	if !changed {
-		return nil
+	collapsedPaths := make([]string, 0, len(next))
+	for path, collapsed := range next {
+		if collapsed {
+			collapsedPaths = append(collapsedPaths, path)
+		}
 	}
-	m.collapseRevision++
-	return m.persistCollapsedGroups()
+	return next, collapsedPaths, changed
 }
 
 func (m *App) persistCollapsedGroups() error {

--- a/apps/bast/internal/ui/view.go
+++ b/apps/bast/internal/ui/view.go
@@ -640,7 +640,7 @@ func (m *App) formHint() string {
 		return groupAssignmentHint()
 	}
 	if isHostForm(m.form) {
-		return hostFormHint(m.form, m.formTextInputActive())
+		return hostFormHint(m.form, m.formTextInputActive(), m.hostSaveHintEnter)
 	}
 	f := m.form
 	action := "󰌑 next"

--- a/apps/bast/internal/ui/view.go
+++ b/apps/bast/internal/ui/view.go
@@ -45,13 +45,7 @@ func (m *App) render() string {
 	styles := m.styles()
 	width := m.terminalWidth()
 	bodyHeight := max(1, m.terminalHeight()-3)
-	header := styles.title.Render(headerTitle) + "  " + m.renderTabs(styles)
-	if m.version != "" && m.version != "dev" {
-		space := width - lipgloss.Width(header) - lipgloss.Width(m.version)
-		if space > 0 {
-			header += strings.Repeat(" ", space) + styles.muted.Render(m.version)
-		}
-	}
+	header := m.renderHeader(styles)
 	var body string
 	if m.statusError && m.status != "" {
 		body = m.renderError(styles)
@@ -71,6 +65,17 @@ func (m *App) render() string {
 	body = lipgloss.NewStyle().Width(width).Height(bodyHeight).Render(body)
 	footer := m.renderFooter(styles)
 	return lipgloss.NewStyle().Width(width).Render(header + "\n" + m.renderHeaderRule(styles) + "\n" + body + "\n" + footer)
+}
+
+func (m *App) renderHeader(s styleSet) string {
+	header := s.title.Render(headerTitle) + "  " + m.renderTabs(s)
+	if m.version != "" && m.version != "dev" {
+		space := m.terminalWidth() - lipgloss.Width(header) - lipgloss.Width(m.version)
+		if space > 0 {
+			header += strings.Repeat(" ", space) + s.muted.Render(m.version)
+		}
+	}
+	return header
 }
 
 func (m *App) renderError(s styleSet) string {
@@ -557,6 +562,9 @@ func (m *App) renderKeyDetail(s styleSet, key keys.Key, width int) string {
 }
 
 func (m *App) renderForm(s styleSet) string {
+	if isGroupAssignmentForm(m.form) {
+		return m.renderGroupAssignmentForm(s)
+	}
 	if isHostForm(m.form) {
 		return m.renderHostForm(s)
 	}
@@ -628,6 +636,9 @@ func (m *App) renderForm(s styleSet) string {
 }
 
 func (m *App) formHint() string {
+	if isGroupAssignmentForm(m.form) {
+		return groupAssignmentHint()
+	}
 	if isHostForm(m.form) {
 		return hostFormHint(m.form, m.formTextInputActive())
 	}
@@ -735,6 +746,7 @@ func helpSections() []helpSection {
 				{"󰌑", "Connect or add suggestion"},
 				{"a", "Add host"},
 				{"e", "Edit or review suggestion"},
+				{"m", "Move host to group"},
 				{"x", "Dismiss history suggestion"},
 				{"d", "Delete host"},
 				{"␣", "Collapse or expand group"},
@@ -930,9 +942,9 @@ func (m *App) renderFooter(s styleSet) string {
 				hint = collapse + " • e rename • a add • v about • ? help"
 			}
 		} else if m.isMobileLayout() {
-			hint = "↑/↓ or j/k move • enter/click Connect • a add • v about • ? help"
+			hint = "↑/↓ or j/k move • enter/click Connect • m group • a add • v about • ? help"
 		} else {
-			hint = "󰌑 connect • ␣ " + m.collapseActionLabel() + " • a add • h hide • v about • ? help"
+			hint = "󰌑 connect • m group • ␣ " + m.collapseActionLabel() + " • a add • h hide • v about • ? help"
 		}
 	} else if m.section == keysSection {
 		hint = "a generate • i import • u add to server • x export • v about • ? help"

--- a/apps/web/content/docs/features/(hosts)/host-management.mdx
+++ b/apps/web/content/docs/features/(hosts)/host-management.mdx
@@ -3,7 +3,7 @@ title: Host management
 description: Add, edit, favorite, hide, and organize SSH hosts with groups, tags, and colors.
 ---
 
-Press `a` to add a host or `e` to edit the selected one. The form keeps the required label and hostname at the top, with separate menus for authentication, advanced SSH settings, and metadata. Press `Ctrl+Enter` to save from anywhere in the form.
+Press `a` to add a host or `e` to edit the selected one. The form keeps the required label and hostname at the top, with separate menus for authentication, advanced SSH settings, and metadata. Click **Save** or press `Ctrl+J` to save from anywhere in the form. `Ctrl+Enter` remains available when your terminal reports it.
 
 ## Connection fields
 
@@ -19,7 +19,7 @@ Choose **Advanced** to configure jump hosts, startup commands, forwarding, keepa
 
 ## Metadata fields
 
-**Groups** use slash paths like `Work/Production`. You can nest up to five levels. Press Space on a group header to collapse or expand it.
+**Groups** use slash paths like `Work/Production`. You can nest up to five levels. Press `m` on a local host, then type to fuzzy-search existing groups. Choose a match, select the create row for a new path, or clear the group with **No group**. Press Space on a group header to collapse or expand it.
 
 **Tags** are comma-separated labels included in search.
 
@@ -34,6 +34,7 @@ Choose **Advanced** to configure jump hosts, startup commands, forwarding, keepa
 | Key | Action |
 | --- | --- |
 | `f` | Favorite the selected host |
+| `m` | Move the selected local host to a group |
 | `h` | Hide a host you rarely need |
 | `.` | Toggle whether hidden hosts appear in the list |
 | `d` | Delete a Bast-managed host |

--- a/apps/web/content/docs/features/(other)/shortcuts.mdx
+++ b/apps/web/content/docs/features/(other)/shortcuts.mdx
@@ -28,6 +28,7 @@ Press `?` inside Bast for the in-app reference. Press `v` for version info, cred
 | Click / tap **Connect** | Connect on narrow terminals ([mobile layout](/docs/features/mobile-view)) |
 | `a` | Add a host |
 | `e` | Edit selected host, or review selected history suggestion |
+| `m` | Move selected local host to a group |
 | `x` | Dismiss selected history suggestion |
 | `d` | Delete selected host |
 | `f` | Toggle favorite |


### PR DESCRIPTION
Closes #32

## Summary

- add a dedicated `m` action for moving the selected host with a searchable pick/create group selector
- add a visible, clickable ` Save ` action to every full host-editor screen
- advertise `Ctrl+J` as a portable save fallback while retaining `Ctrl+Enter`
- document the new interactions and cover them with focused UI tests

## Grouping workflow

Pressing `m` on a selected, non-synced host opens a focused **Move host** search:

- an empty search lists **No group** plus existing normalized group paths, including implicit parent paths
- the host's current group is highlighted initially
- typing fuzzy-filters and ranks existing paths
- when there is no exact normalized match, **Create "…"** appears beside the best result
- `Enter` applies the highlighted existing/custom path, while `Esc` cancels
- choosing **No group** clears the assignment

Custom paths continue through the existing metadata normalization and validation rules, so this does not add another host configuration format. Moving a host also preserves its selection and expands a collapsed destination path so the result remains visible. Synced provider hosts keep their existing read-only behavior.

### Why `m` instead of `g`?

The issue suggested `g` or a similar binding. Bast already uses Vim-style `g` / `G` navigation for jump-to-top / jump-to-bottom. `m` reads as **move to group**, avoids breaking an existing documented binding, and keeps the grouping action adjacent to the host-list workflow rather than the full editor.

## Saving workflow

The host editor now renders a purple top-right ` Save ` action matching the existing ` Connect ` action. It is available on the editor hub and its subsections, truncates long/wide titles before the button, and sends clicks through the same field-commit, validation, and submit path as keyboard saves.

The footer now advertises `Ctrl+J` while `Ctrl+Enter` remains supported for compatibility:

- `Ctrl+Enter` can depend on enhanced terminal key reporting and is intercepted by Ghostty's default fullscreen binding in the reported setup
- `Ctrl+J` is a portable LF control input that Bubble Tea can distinguish from Enter's CR in raw mode
- `Ctrl+S` was considered, but can be intercepted by terminal XON/XOFF flow control before the app receives it

Mouse reporting is enabled for full host editors only; unrelated forms retain their prior keyboard-only behavior.

## Reviewer notes

- group-picker behavior and fuzzy ranking are isolated in `group_form.go`
- assignment still persists through Bast's existing metadata-backed group path handling
- Save click geometry uses terminal cell widths, including wide Unicode titles; `github.com/charmbracelet/x/ansi` is now a direct dependency because it is used for cell-aware truncation
- docs are updated for both host management and the shortcut reference

## Verification

- `bun run check`
- focused UI coverage for existing/fuzzy/custom/cleared group choices, pasted input, cancellation, synced-host rejection, collapsed destinations, retained selection, `Ctrl+J`, retained `Ctrl+Enter`, Save clicks, wide titles, narrow layouts, and non-host mouse behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move local hosts into existing or new groups with the `m` shortcut.
  * Search groups with fuzzy matching, clear assignments, and create nested groups.
  * Use mouse clicks to activate the host form’s Save button.
  * Save host forms with `Ctrl+J` from any field; `Ctrl+Enter` remains supported.
  * Automatically expand collapsed group paths when revealing assigned hosts.

* **Documentation**
  * Updated host management and shortcut documentation for grouping and save controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->