### PR TITLE
feat: inline file preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ User-facing changes to Bast (CLI, installers, and behaviour). Website-only chang
 
 ### Added
 
+- Files tab preview: press `o` or Enter on a file for a floating peek at text, JSON, and PDF contents.
 - First TUI launch with no hosts shows a skippable start chooser (add, history, Vault, Sync). Machines that already have SSH hosts skip it. `BAST_NO_ONBOARDING=1` disables it. About (`v`) replays it with `o`.
 - About includes a Sponsor chip that opens https://bast.sh/sponsor.
 - `bast doctor` diagnoses SSH config, keys, permissions, and Bast setup. Press `D` in the TUI (not in Files). `--fix` repairs the Bast Include and modes OpenSSH will refuse; `--json` exposes stable finding ids.

--- a/apps/bast/go.mod
+++ b/apps/bast/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/term v0.2.2
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/pkg/sftp v1.13.11
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0

--- a/apps/bast/go.sum
+++ b/apps/bast/go.sum
@@ -30,6 +30,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=

--- a/apps/bast/internal/files/preview.go
+++ b/apps/bast/internal/files/preview.go
@@ -1,0 +1,396 @@
+package files
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"unicode/utf8"
+
+	pdf "github.com/ledongthuc/pdf"
+)
+
+const (
+	// PreviewTextLimit is the maximum prefix read for text and JSON.
+	PreviewTextLimit = 512 << 10
+	// PreviewPDFLimit is the maximum whole-file size for PDF extraction.
+	// PDFs store the xref at EOF, so a prefix is not enough.
+	PreviewPDFLimit = 8 << 20
+	previewSniff    = 8 << 10
+)
+
+// PreviewKind is the display class for a file peek.
+type PreviewKind string
+
+const (
+	PreviewText      PreviewKind = "text"
+	PreviewJSON      PreviewKind = "json"
+	PreviewPDF       PreviewKind = "pdf"
+	PreviewBinary    PreviewKind = "binary"
+	PreviewImage     PreviewKind = "image"
+	PreviewDirectory PreviewKind = "directory"
+	PreviewOther     PreviewKind = "other"
+)
+
+// Preview is a bounded peek at a local or remote file.
+type Preview struct {
+	Name      string
+	Path      string
+	Kind      PreviewKind
+	Size      int64
+	Text      string
+	Truncated bool
+	Pages     int
+	Reason    string
+}
+
+var previewTextExt = map[string]struct{}{
+	".txt": {}, ".md": {}, ".markdown": {}, ".log": {}, ".csv": {}, ".tsv": {},
+	".env": {}, ".ini": {}, ".conf": {}, ".cfg": {}, ".toml": {}, ".xml": {},
+	".html": {}, ".css": {}, ".js": {}, ".ts": {}, ".jsx": {}, ".tsx": {},
+	".go": {}, ".rs": {}, ".py": {}, ".rb": {}, ".sh": {}, ".bash": {},
+	".zsh": {}, ".fish": {}, ".yaml": {}, ".yml": {}, ".sql": {}, ".graphql": {},
+	".dockerfile": {}, ".svg": {},
+}
+
+var previewTextName = map[string]struct{}{
+	"dockerfile": {}, "makefile": {}, "cmakelists.txt": {},
+	".gitignore": {}, ".editorconfig": {},
+}
+
+var previewImageExt = map[string]struct{}{
+	".png": {}, ".jpg": {}, ".jpeg": {}, ".gif": {}, ".webp": {},
+	".ico": {}, ".bmp": {}, ".tif": {}, ".tiff": {}, ".heic": {}, ".avif": {},
+}
+
+// ReadPreview returns a bounded preview of path on ep.
+// size is used when > 0 (listing size); otherwise Stat fills it in.
+func ReadPreview(ctx context.Context, ep Endpoint, filePath string, size int64, name string) (Preview, error) {
+	if err := ctx.Err(); err != nil {
+		return Preview{}, err
+	}
+	cleaned, err := cleanPreviewPath(ep, filePath)
+	if err != nil {
+		return Preview{}, err
+	}
+	if name == "" {
+		name = BaseName(cleaned)
+	}
+	out := Preview{Name: name, Path: cleaned}
+
+	info, err := statPreview(ep, cleaned)
+	if err != nil {
+		return Preview{}, err
+	}
+	if info.IsDir() {
+		out.Kind = PreviewDirectory
+		out.Size = info.Size()
+		return out, nil
+	}
+	if size <= 0 {
+		size = info.Size()
+	}
+	out.Size = size
+
+	named := kindFromName(name)
+	switch named {
+	case PreviewImage:
+		out.Kind = PreviewImage
+		return out, nil
+	case PreviewPDF:
+		if size > PreviewPDFLimit {
+			out.Kind = PreviewPDF
+			out.Reason = "too large to preview"
+			return out, nil
+		}
+	}
+
+	src, err := openPreview(ep, cleaned)
+	if err != nil {
+		return Preview{}, err
+	}
+	defer src.Close()
+
+	head, _, err := readCapped(ctx, src, previewSniff)
+	if err != nil {
+		return Preview{}, err
+	}
+	kind := named
+	if kind == PreviewOther {
+		kind = kindFromSniff(head)
+	}
+	if kind != PreviewPDF && isBinary(head) {
+		out.Kind = PreviewBinary
+		return out, nil
+	}
+	if kind == PreviewImage {
+		out.Kind = PreviewImage
+		return out, nil
+	}
+
+	want := PreviewTextLimit
+	if kind == PreviewPDF {
+		if size > PreviewPDFLimit {
+			out.Kind = PreviewPDF
+			out.Reason = "too large to preview"
+			return out, nil
+		}
+		want = PreviewPDFLimit
+	}
+	data, truncated, err := continueCapped(ctx, src, head, want)
+	if err != nil {
+		return Preview{}, err
+	}
+
+	switch kind {
+	case PreviewPDF:
+		if truncated {
+			out.Kind = PreviewPDF
+			out.Reason = "too large to preview"
+			return out, nil
+		}
+		text, pages, err := extractPDF(ctx, data)
+		out.Kind = PreviewPDF
+		out.Pages = pages
+		if err != nil || strings.TrimSpace(text) == "" {
+			out.Reason = "no extractable text"
+			return out, nil
+		}
+		out.Text = sanitizePreviewText(text)
+		return out, nil
+	default:
+		if kind == PreviewJSON {
+			if pretty, ok := indentJSON(data); ok {
+				out.Kind = PreviewJSON
+				out.Text = pretty
+				out.Truncated = truncated
+				return out, nil
+			}
+			out.Kind = PreviewText
+			out.Text = sanitizePreviewText(string(data))
+			out.Truncated = truncated
+			return out, nil
+		}
+		out.Kind = PreviewText
+		out.Text = sanitizePreviewText(string(data))
+		out.Truncated = truncated
+		return out, nil
+	}
+}
+
+func cleanPreviewPath(ep Endpoint, filePath string) (string, error) {
+	if ep.local() {
+		return CleanLocal(filePath)
+	}
+	return CleanRemote(filePath)
+}
+
+func statPreview(ep Endpoint, cleaned string) (os.FileInfo, error) {
+	if ep.local() {
+		return os.Stat(cleaned)
+	}
+	return StatRemote(ep.Session, cleaned)
+}
+
+func openPreview(ep Endpoint, cleaned string) (io.ReadCloser, error) {
+	if ep.local() {
+		return os.Open(cleaned)
+	}
+	return ep.Session.Client().Open(cleaned)
+}
+
+func kindFromName(name string) PreviewKind {
+	lower := strings.ToLower(name)
+	if _, ok := previewTextName[lower]; ok {
+		return PreviewText
+	}
+	ext := strings.ToLower(path.Ext(name))
+	switch ext {
+	case ".json", ".jsonc":
+		return PreviewJSON
+	case ".pdf":
+		return PreviewPDF
+	}
+	if _, ok := previewImageExt[ext]; ok {
+		return PreviewImage
+	}
+	if _, ok := previewTextExt[ext]; ok {
+		return PreviewText
+	}
+	return PreviewOther
+}
+
+func kindFromSniff(data []byte) PreviewKind {
+	if isPDFMagic(data) {
+		return PreviewPDF
+	}
+	if isImageMagic(data) {
+		return PreviewImage
+	}
+	if isBinary(data) {
+		return PreviewBinary
+	}
+	if looksJSON(data) {
+		return PreviewJSON
+	}
+	return PreviewText
+}
+
+func isPDFMagic(data []byte) bool {
+	return bytes.HasPrefix(bytes.TrimLeft(data, "\x00"), []byte("%PDF"))
+}
+
+func isImageMagic(data []byte) bool {
+	switch {
+	case bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")):
+		return true
+	case len(data) >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff:
+		return true
+	case bytes.HasPrefix(data, []byte("GIF87a")), bytes.HasPrefix(data, []byte("GIF89a")):
+		return true
+	case len(data) >= 12 && bytes.HasPrefix(data, []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")):
+		return true
+	case bytes.HasPrefix(data, []byte("BM")):
+		return true
+	case bytes.HasPrefix(data, []byte("II*\x00")), bytes.HasPrefix(data, []byte("MM\x00*")):
+		return true
+	}
+	return false
+}
+
+func isBinary(data []byte) bool {
+	if bytes.IndexByte(data, 0) >= 0 {
+		return true
+	}
+	if len(data) == 0 {
+		return false
+	}
+	non := 0
+	for _, c := range data {
+		if c < 0x20 && c != '\t' && c != '\n' && c != '\r' && c != '\f' {
+			non++
+		}
+	}
+	return non*100/len(data) > 15
+}
+
+func looksJSON(data []byte) bool {
+	trim := bytes.TrimSpace(data)
+	return len(trim) > 0 && (trim[0] == '{' || trim[0] == '[')
+}
+
+func indentJSON(data []byte) (string, bool) {
+	trim := bytes.TrimSpace(data)
+	if !json.Valid(trim) {
+		return "", false
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, trim, "", "  "); err != nil {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+func sanitizePreviewText(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, "\uFFFD")
+}
+
+func readCapped(ctx context.Context, r io.Reader, capBytes int) ([]byte, bool, error) {
+	if capBytes < 0 {
+		capBytes = 0
+	}
+	buf := make([]byte, capBytes+1)
+	n := 0
+	for n < len(buf) {
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		nn, err := r.Read(buf[n:])
+		n += nn
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		if nn == 0 {
+			break
+		}
+	}
+	if n > capBytes {
+		return buf[:capBytes], true, nil
+	}
+	return buf[:n], false, nil
+}
+
+func continueCapped(ctx context.Context, r io.Reader, head []byte, capBytes int) ([]byte, bool, error) {
+	if len(head) > capBytes {
+		return head[:capBytes], true, nil
+	}
+	if len(head) == capBytes {
+		// One extra byte tells us whether more remains.
+		extra := make([]byte, 1)
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		n, err := r.Read(extra)
+		if n > 0 {
+			return head, true, nil
+		}
+		if err != nil && err != io.EOF {
+			return nil, false, err
+		}
+		return head, false, nil
+	}
+	rest, truncated, err := readCapped(ctx, r, capBytes-len(head))
+	if err != nil {
+		return nil, false, err
+	}
+	out := make([]byte, 0, len(head)+len(rest))
+	out = append(out, head...)
+	out = append(out, rest...)
+	return out, truncated, nil
+}
+
+func extractPDF(ctx context.Context, data []byte) (text string, pages int, err error) {
+	if err := ctx.Err(); err != nil {
+		return "", 0, err
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			text, pages = "", 0
+			err = fmt.Errorf("pdf: %v", rec)
+		}
+	}()
+	reader, err := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", 0, err
+	}
+	pages = reader.NumPage()
+	var b strings.Builder
+	for i := 1; i <= pages; i++ {
+		if err := ctx.Err(); err != nil {
+			return "", pages, err
+		}
+		page := reader.Page(i)
+		if page.V.IsNull() {
+			continue
+		}
+		plain, err := page.GetPlainText(nil)
+		if err != nil || strings.TrimSpace(plain) == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(plain)
+	}
+	return strings.TrimSpace(b.String()), pages, nil
+}

--- a/apps/bast/internal/files/preview_test.go
+++ b/apps/bast/internal/files/preview_test.go
@@ -1,0 +1,271 @@
+package files
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadPreviewTextTruncates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.log")
+	payload := bytes.Repeat([]byte("a"), PreviewTextLimit+64)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, int64(len(payload)), "big.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewText {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if !got.Truncated {
+		t.Fatal("expected truncated")
+	}
+	if len(got.Text) != PreviewTextLimit {
+		t.Fatalf("len = %d, want %d", len(got.Text), PreviewTextLimit)
+	}
+}
+
+func TestReadPreviewBinaryNUL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "blob.bin")
+	if err := os.WriteFile(path, []byte("hello\x00world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, 0, "blob.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewBinary {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != "" {
+		t.Fatalf("binary text = %q", got.Text)
+	}
+}
+
+func TestReadPreviewJSONIndentKeepsKeyOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.json")
+	raw := []byte(`{"z":1,"a":2}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, 0, "notes.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewJSON {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if !strings.Contains(got.Text, `"z": 1`) || !strings.Contains(got.Text, `"a": 2`) {
+		t.Fatalf("pretty = %q", got.Text)
+	}
+	if strings.Index(got.Text, `"z"`) > strings.Index(got.Text, `"a"`) {
+		t.Fatalf("key order lost: %q", got.Text)
+	}
+}
+
+func TestReadPreviewTextFileWithJSONStaysText(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.txt")
+	raw := []byte(`{"z":1,"a":2}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, 0, "notes.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewText {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != string(raw) {
+		t.Fatalf("text = %q", got.Text)
+	}
+}
+
+func TestReadPreviewInvalidJSONIsText(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.json")
+	raw := []byte(`{"z":1,`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, 0, "broken.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewText {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != string(raw) {
+		t.Fatalf("text = %q", got.Text)
+	}
+}
+
+func TestReadPreviewPDFExtractsText(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hello.pdf")
+	payload := helloPDF("Hello preview")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, int64(len(payload)), "hello.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewPDF {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if !strings.Contains(got.Text, "Hello preview") {
+		t.Fatalf("pdf text = %q reason = %q", got.Text, got.Reason)
+	}
+	if got.Pages < 1 {
+		t.Fatalf("pages = %d", got.Pages)
+	}
+}
+
+func TestReadPreviewPDFEmptyHasReason(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.pdf")
+	payload := helloPDF("")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, int64(len(payload)), "empty.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewPDF {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != "" {
+		t.Fatalf("empty pdf text = %q", got.Text)
+	}
+	if got.Reason != "no extractable text" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+}
+
+func TestReadPreviewPDFOversizeDoesNotNeedBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "huge.pdf")
+	if err := os.WriteFile(path, helloPDF("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, PreviewPDFLimit+1, "huge.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewPDF {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != "" {
+		t.Fatalf("oversize should not extract, text = %q", got.Text)
+	}
+	if got.Reason != "too large to preview" {
+		t.Fatalf("reason = %q", got.Reason)
+	}
+}
+
+func TestReadPreviewMalformedPDFDoesNotPanic(t *testing.T) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("ReadPreview panicked: %v", rec)
+		}
+	}()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.pdf")
+	payload := []byte("%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n%%EOF\n")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = ReadPreview(context.Background(), Endpoint{}, path, int64(len(payload)), "bad.pdf")
+}
+
+func TestExtractPDFRecoversPanic(t *testing.T) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Fatalf("extractPDF panicked: %v", rec)
+		}
+	}()
+	_, _, _ = extractPDF(context.Background(), []byte("%PDF-1.4\ntrailer\n<< /Root 99 0 R >>\n%%EOF\n"))
+}
+
+func TestReadPreviewDirectory(t *testing.T) {
+	dir := t.TempDir()
+	got, err := ReadPreview(context.Background(), Endpoint{}, dir, 0, "nested")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewDirectory {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+}
+
+func TestReadPreviewRejectsRemoteTraversal(t *testing.T) {
+	_, err := CleanRemote("/tmp/../etc/passwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := JoinRemote("/tmp", "../x"); err == nil {
+		t.Fatal("expected invalid join")
+	}
+}
+
+func TestReadPreviewImageByExtensionSkipsBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(path, []byte("not-a-png-but-named-so"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPreview(context.Background(), Endpoint{}, path, 0, "shot.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != PreviewImage {
+		t.Fatalf("kind = %q", got.Kind)
+	}
+	if got.Text != "" {
+		t.Fatalf("image text = %q", got.Text)
+	}
+}
+
+func helloPDF(text string) []byte {
+	escaped := strings.NewReplacer(`\`, `\\`, `(`, `\(`, `)`, `\)`).Replace(text)
+	var stream string
+	if text == "" {
+		stream = "BT ET\n"
+	} else {
+		stream = fmt.Sprintf("BT /F1 12 Tf 72 720 Td (%s) Tj ET\n", escaped)
+	}
+	objs := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+		fmt.Sprintf("<< /Length %d >>\nstream\n%s\nendstream", len(stream), strings.TrimRight(stream, "\n")),
+		"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+	}
+	var buf bytes.Buffer
+	buf.WriteString("%PDF-1.4\n")
+	offsets := make([]int, len(objs)+1)
+	for i, obj := range objs {
+		offsets[i+1] = buf.Len()
+		fmt.Fprintf(&buf, "%d 0 obj\n%s\nendobj\n", i+1, obj)
+	}
+	startxref := buf.Len()
+	fmt.Fprintf(&buf, "xref\n0 %d\n", len(objs)+1)
+	buf.WriteString("0000000000 65535 f \n")
+	for i := 1; i <= len(objs); i++ {
+		fmt.Fprintf(&buf, "%010d 00000 n \n", offsets[i])
+	}
+	fmt.Fprintf(&buf, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", len(objs)+1, startxref)
+	return buf.Bytes()
+}

--- a/apps/bast/internal/ui/app.go
+++ b/apps/bast/internal/ui/app.go
@@ -824,6 +824,8 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.handleFilesTransferProgress(msg)
 	case filesOpDoneMsg:
 		return m, m.handleFilesOpDone(msg)
+	case filesPreviewMsg:
+		return m, m.handleFilesPreviewMsg(msg)
 	case clearStatusMsg:
 		if uint64(msg) == m.statusID && !m.statusError {
 			m.status = ""

--- a/apps/bast/internal/ui/files.go
+++ b/apps/bast/internal/ui/files.go
@@ -77,6 +77,7 @@ type filesState struct {
 	jump        filesJump
 	chmod       filesChmod
 	info        bool
+	preview     filesPreview
 	deletePaths []string
 	ready       bool
 }
@@ -263,6 +264,9 @@ func (m *App) filesEndpoint(pane *filesPane) files.Endpoint {
 
 func (m *App) renderFiles(s styleSet) string {
 	m.initFilesState()
+	if m.files.preview.active {
+		return m.renderFilesPreview(s)
+	}
 	layout := m.panelLayout()
 	left := m.renderFilesSide(s, 0, layout.listHeight, layout.listWidth)
 	right := m.renderFilesSide(s, 1, layout.detailHeight, layout.detailWidth)
@@ -459,6 +463,9 @@ func (m *App) updateFilesKeys(key string) (tea.Model, tea.Cmd) {
 	if m.files.chmod.active {
 		return m.updateFilesChmod(key)
 	}
+	if m.files.preview.active {
+		return m.updateFilesPreview(key)
+	}
 	if m.files.info {
 		return m.updateFilesInfo(key)
 	}
@@ -529,8 +536,12 @@ func (m *App) updateFilesKeys(key string) (tea.Model, tea.Cmd) {
 		return m.moveFilesCursorHome()
 	case "end", "G":
 		return m.moveFilesCursorEnd()
-	case "enter", "l":
+	case "enter":
 		return m.activateFilesSelection()
+	case "l":
+		return m.enterFilesDirectory()
+	case "o":
+		return m.openFilesPreview()
 	case "backspace", "h", "ctrl+h":
 		if pane.pickingHost() {
 			return m, nil
@@ -582,6 +593,9 @@ func (m *App) filesTyping() bool {
 		return false
 	}
 	if m.files.chmod.active {
+		return true
+	}
+	if m.files.preview.active {
 		return true
 	}
 	if m.files.info {
@@ -762,6 +776,21 @@ func (m *App) activateFilesSelection() (tea.Model, tea.Cmd) {
 		return m, m.connectFilesHost(m.files.focus, hosts[pane.hostCursor])
 	}
 	entry, ok := pane.selectedEntry()
+	if !ok {
+		return m, nil
+	}
+	if !entry.IsDir {
+		return m.openFilesPreview()
+	}
+	return m.enterFilesDirectory()
+}
+
+func (m *App) enterFilesDirectory() (tea.Model, tea.Cmd) {
+	pane := m.filesFocusedPane()
+	if pane.pickingHost() {
+		return m.activateFilesSelection()
+	}
+	entry, ok := pane.selectedEntry()
 	if !ok || !entry.IsDir {
 		return m, nil
 	}
@@ -909,6 +938,10 @@ func (m *App) filesRowAt(paneIndex, relY int) (index int, header, ok bool) {
 
 func (m *App) updateFilesMouse(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	m.initFilesState()
+	if m.files.preview.active {
+		m.closeFilesPreview()
+		return m, nil
+	}
 	if m.files.transfer.active {
 		return m, nil
 	}
@@ -972,6 +1005,15 @@ func (m *App) updateFilesMouse(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *App) updateFilesMouseWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
+	if m.files.preview.active {
+		switch msg.Mouse().Button {
+		case tea.MouseWheelUp:
+			m.scrollFilesPreview(-3)
+		case tea.MouseWheelDown:
+			m.scrollFilesPreview(3)
+		}
+		return m, nil
+	}
 	if m.files.chmod.active {
 		return m, nil
 	}
@@ -1008,6 +1050,12 @@ func (m *App) filesFooterStatus() string {
 	m.initFilesState()
 	if m.files.chmod.active {
 		return m.filesChmodHint()
+	}
+	if m.files.preview.active {
+		if m.files.preview.loading {
+			return "loading… o/esc close"
+		}
+		return "j/k scroll · [ ] file · o/esc close"
 	}
 	if m.files.info {
 		if m.filesFocusedPane().kind == filesPaneLocal && !platform.SupportsPOSIXPermissions() {

--- a/apps/bast/internal/ui/files_info.go
+++ b/apps/bast/internal/ui/files_info.go
@@ -25,11 +25,12 @@ func (m *App) closeFilesInfo() {
 	m.files.info = false
 }
 
-// clearFilesOverlays dismisses chmod/info when leaving the Files section
+// clearFilesOverlays dismisses chmod/info/preview when leaving the Files section
 // so they do not stick over Hosts, Keys, or Sync.
 func (m *App) clearFilesOverlays() {
 	m.closeFilesChmod()
 	m.closeFilesInfo()
+	m.closeFilesPreview()
 }
 
 func (m *App) updateFilesInfo(key string) (tea.Model, tea.Cmd) {
@@ -40,6 +41,9 @@ func (m *App) updateFilesInfo(key string) (tea.Model, tea.Cmd) {
 	case "esc", "i", "q":
 		m.closeFilesInfo()
 		return m, nil
+	case "o":
+		m.closeFilesInfo()
+		return m.openFilesPreview()
 	case "tab":
 		m.files.focus = 1 - m.files.focus
 		return m, nil

--- a/apps/bast/internal/ui/files_preview.go
+++ b/apps/bast/internal/ui/files_preview.go
@@ -1,0 +1,303 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"bast/internal/files"
+)
+
+const (
+	filesPreviewLocalTimeout  = 8 * time.Second
+	filesPreviewRemoteTimeout = 20 * time.Second
+)
+
+type filesPreview struct {
+	active  bool
+	loading bool
+	err     string
+	pane    int
+	path    string
+	gen     uint64
+	offset  int
+	result  files.Preview
+	cancel  context.CancelFunc
+}
+
+type filesPreviewMsg struct {
+	gen     uint64
+	preview files.Preview
+	err     error
+}
+
+func (m *App) openFilesPreview() (tea.Model, tea.Cmd) {
+	pane := m.filesFocusedPane()
+	if pane.pickingHost() {
+		return m, nil
+	}
+	entry, ok := pane.selectedEntry()
+	if !ok {
+		return m, m.setNotice("Nothing selected")
+	}
+	if entry.IsDir {
+		return m, m.setNotice("Not a file")
+	}
+	if m.files.preview.active && m.files.preview.path == entry.Path {
+		m.closeFilesPreview()
+		return m, nil
+	}
+
+	m.closeFilesInfo()
+	if m.files.preview.cancel != nil {
+		m.files.preview.cancel()
+	}
+	m.files.preview.gen++
+	gen := m.files.preview.gen
+	timeout := filesPreviewLocalTimeout
+	if pane.kind == filesPaneRemote {
+		timeout = filesPreviewRemoteTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	m.files.preview = filesPreview{
+		active:  true,
+		loading: true,
+		pane:    m.files.focus,
+		path:    entry.Path,
+		gen:     gen,
+		cancel:  cancel,
+	}
+	ep := m.filesEndpoint(pane)
+	name := entry.Name
+	path := entry.Path
+	size := entry.Size
+	return m, func() tea.Msg {
+		defer cancel()
+		preview, err := files.ReadPreview(ctx, ep, path, size, name)
+		return filesPreviewMsg{gen: gen, preview: preview, err: err}
+	}
+}
+
+func (m *App) closeFilesPreview() {
+	if m.files.preview.cancel != nil {
+		m.files.preview.cancel()
+	}
+	m.files.preview = filesPreview{}
+}
+
+func (m *App) handleFilesPreviewMsg(msg filesPreviewMsg) tea.Cmd {
+	if !m.files.preview.active || msg.gen != m.files.preview.gen {
+		return nil
+	}
+	m.files.preview.loading = false
+	m.files.preview.offset = 0
+	if msg.err != nil {
+		m.files.preview.err = msg.err.Error()
+		m.files.preview.result = files.Preview{}
+		return nil
+	}
+	m.files.preview.err = ""
+	m.files.preview.result = msg.preview
+	return nil
+}
+
+func (m *App) updateFilesPreview(key string) (tea.Model, tea.Cmd) {
+	if !m.files.preview.active {
+		return m, nil
+	}
+	page := m.filesPreviewPage()
+	switch key {
+	case "o", "esc", "q":
+		m.closeFilesPreview()
+		return m, nil
+	case "i":
+		m.closeFilesPreview()
+		return m.openFilesInfo()
+	case "p":
+		m.closeFilesPreview()
+		return m.openFilesChmodMenu()
+	case "up", "k":
+		m.scrollFilesPreview(-1)
+	case "down", "j":
+		m.scrollFilesPreview(1)
+	case "pgup":
+		m.scrollFilesPreview(-page)
+	case "pgdown":
+		m.scrollFilesPreview(page)
+	case "g", "home":
+		m.files.preview.offset = 0
+	case "G", "end":
+		m.files.preview.offset = m.maxFilesPreviewOffset()
+	case "[":
+		return m.stepFilesPreview(-1)
+	case "]":
+		return m.stepFilesPreview(1)
+	}
+	return m, nil
+}
+
+func (m *App) stepFilesPreview(delta int) (tea.Model, tea.Cmd) {
+	paneIndex := m.files.preview.pane
+	if paneIndex < 0 || paneIndex > 1 {
+		paneIndex = m.files.focus
+	}
+	pane := &m.files.panes[paneIndex]
+	start := pane.cursor
+	for i := 1; i < len(pane.entries); i++ {
+		idx := start + delta*i
+		if idx < 0 || idx >= len(pane.entries) {
+			return m, nil
+		}
+		if pane.entries[idx].IsDir {
+			continue
+		}
+		pane.cursor = idx
+		pane.clamp()
+		m.files.focus = paneIndex
+		return m.openFilesPreview()
+	}
+	return m, nil
+}
+
+func (m *App) scrollFilesPreview(delta int) {
+	m.files.preview.offset += delta
+	m.clampFilesPreviewOffset()
+}
+
+func (m *App) clampFilesPreviewOffset() {
+	if m.files.preview.offset < 0 {
+		m.files.preview.offset = 0
+	}
+	if maxOffset := m.maxFilesPreviewOffset(); m.files.preview.offset > maxOffset {
+		m.files.preview.offset = maxOffset
+	}
+}
+
+func (m *App) maxFilesPreviewOffset() int {
+	body := m.filesPreviewBodyLines(m.filesPreviewContentWidth())
+	return max(0, len(body)-m.filesPreviewPage())
+}
+
+func (m *App) filesPreviewPage() int {
+	return max(1, m.filesPreviewInnerHeight()-2)
+}
+
+func (m *App) filesPreviewContentWidth() int {
+	termW := m.terminalWidth()
+	if m.isMobileLayout() {
+		return max(16, termW-8)
+	}
+	return max(16, min(80, termW-10))
+}
+
+func (m *App) filesPreviewInnerHeight() int {
+	bodyH := max(1, m.terminalHeight()-3)
+	if m.isMobileLayout() {
+		return max(6, bodyH-4)
+	}
+	return max(8, bodyH-6)
+}
+
+func (m *App) renderFilesPreview(s styleSet) string {
+	innerW := m.filesPreviewContentWidth()
+	title := m.filesPreviewTitle(innerW)
+	body := m.filesPreviewBodyLines(innerW)
+	viewH := m.filesPreviewPage()
+	m.clampFilesPreviewOffset()
+	offset := m.files.preview.offset
+	end := min(len(body), offset+viewH)
+	var b strings.Builder
+	b.WriteString(s.active.Render(title))
+	visible := body[offset:end]
+	if len(visible) == 0 {
+		b.WriteString("\n")
+	}
+	for i, line := range visible {
+		b.WriteString("\n")
+		if m.files.preview.err != "" && offset+i == 0 {
+			b.WriteString(s.error.Width(innerW).Render(line))
+			continue
+		}
+		if m.files.preview.loading || m.files.preview.result.Text == "" {
+			b.WriteString(s.muted.Width(innerW).Render(line))
+			continue
+		}
+		b.WriteString(s.value.Width(innerW).Render(line))
+	}
+	panel := lipgloss.NewStyle().
+		Width(innerW).
+		Padding(1, 2).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#6B7280")).
+		Render(b.String())
+	return lipgloss.Place(m.terminalWidth(), max(1, m.terminalHeight()-3), lipgloss.Center, lipgloss.Center, panel)
+}
+
+func (m *App) filesPreviewTitle(width int) string {
+	p := m.files.preview
+	if p.loading {
+		name := files.BaseName(p.path)
+		if name == "" {
+			name = "file"
+		}
+		return truncate(name, width)
+	}
+	if p.err != "" {
+		name := files.BaseName(p.path)
+		return truncate(name, width)
+	}
+	res := p.result
+	name := res.Name
+	if name == "" {
+		name = files.BaseName(p.path)
+	}
+	parts := []string{name, string(res.Kind), files.FormatSize(res.Size)}
+	if res.Truncated {
+		parts = append(parts, "truncated")
+	}
+	return truncate(strings.Join(parts, " · "), width)
+}
+
+func (m *App) filesPreviewBodyLines(width int) []string {
+	p := m.files.preview
+	if p.loading {
+		return []string{"Loading…"}
+	}
+	if p.err != "" {
+		return wrapPreviewLines(p.err, width)
+	}
+	if p.result.Text != "" {
+		return wrapPreviewLines(p.result.Text, width)
+	}
+	if p.result.Reason != "" {
+		return wrapPreviewLines(p.result.Reason, width)
+	}
+	return nil
+}
+
+func wrapPreviewLines(text string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	maxSource := width * 2
+	var out []string
+	for _, line := range strings.Split(text, "\n") {
+		runes := []rune(line)
+		if len(runes) > maxSource {
+			runes = append(runes[:maxSource-1], '…')
+		}
+		if len(runes) == 0 {
+			out = append(out, "")
+			continue
+		}
+		for len(runes) > width {
+			out = append(out, string(runes[:width]))
+			runes = runes[width:]
+		}
+		out = append(out, string(runes))
+	}
+	return out
+}

--- a/apps/bast/internal/ui/files_test.go
+++ b/apps/bast/internal/ui/files_test.go
@@ -490,8 +490,9 @@ func TestClearFilesOverlaysOnLeave(t *testing.T) {
 	_ = m.enterFilesSection()
 	m.files.info = true
 	m.files.chmod = filesChmod{active: true, mode: 0o644}
+	m.files.preview = filesPreview{active: true, path: "/tmp/x"}
 	m.clearFilesOverlays()
-	if m.files.info || m.files.chmod.active {
+	if m.files.info || m.files.chmod.active || m.files.preview.active {
 		t.Fatal("overlays should clear when leaving Files")
 	}
 }
@@ -696,6 +697,236 @@ func TestFilesConnectErrorNotice(t *testing.T) {
 	got = filesConnectErrorNotice(fmt.Errorf("Permission denied (publickey)"))
 	if !strings.Contains(got, "Auth failed") {
 		t.Fatalf("auth notice = %q", got)
+	}
+}
+
+func applyFilesPreview(t *testing.T, m *App) {
+	t.Helper()
+	_, cmd := m.openFilesPreview()
+	if !m.files.preview.active {
+		t.Fatal("preview should be active")
+	}
+	if cmd == nil {
+		t.Fatal("expected preview load")
+	}
+	m.Update(cmd())
+	if m.files.preview.loading {
+		t.Fatal("preview should finish loading")
+	}
+}
+
+func selectFilesEntry(m *App, name string) {
+	for i, entry := range m.files.panes[m.files.focus].entries {
+		if entry.Name == name {
+			m.files.panes[m.files.focus].cursor = i
+			return
+		}
+	}
+}
+
+func TestFilesPreviewJSONOverlay(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.json")
+	if err := os.WriteFile(path, []byte(`{"z":1,"a":2}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+	selectFilesEntry(m, "notes.json")
+
+	applyFilesPreview(t, m)
+	body := m.renderFiles(m.styles())
+	if !strings.Contains(body, "notes.json") {
+		t.Fatalf("title missing:\n%s", body)
+	}
+	if !strings.Contains(body, `"z": 1`) {
+		t.Fatalf("expected pretty JSON:\n%s", body)
+	}
+
+	m.updateFilesKeys("o")
+	if m.files.preview.active {
+		t.Fatal("o should toggle preview closed")
+	}
+
+	applyFilesPreview(t, m)
+	m.updateFilesKeys("esc")
+	if m.files.preview.active {
+		t.Fatal("esc should close preview")
+	}
+
+	applyFilesPreview(t, m)
+	m.updateFilesKeys("q")
+	if m.files.preview.active {
+		t.Fatal("q should close preview")
+	}
+}
+
+func TestFilesPreviewDirectoryNotice(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+	selectFilesEntry(m, "nested")
+	m.updateFilesKeys("o")
+	if m.files.preview.active {
+		t.Fatal("o on a directory should not open preview")
+	}
+	if m.status != "Not a file" {
+		t.Fatalf("status = %q", m.status)
+	}
+}
+
+func TestFilesPreviewSpaceStillMarks(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+	selectFilesEntry(m, "a.txt")
+	m.updateFilesKeys("space")
+	if len(m.files.panes[0].marked) != 1 {
+		t.Fatalf("space should still mark, marked=%v", m.files.panes[0].marked)
+	}
+	if m.files.preview.active {
+		t.Fatal("space should not open preview")
+	}
+}
+
+func TestFilesEnterFilePreviewsAndDirEnters(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "nested")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+
+	selectFilesEntry(m, "a.txt")
+	_, cmd := m.updateFilesKeys("enter")
+	if !m.files.preview.active {
+		t.Fatal("enter on a file should preview")
+	}
+	if cmd != nil {
+		m.Update(cmd())
+	}
+	m.closeFilesPreview()
+
+	selectFilesEntry(m, "a.txt")
+	m.updateFilesKeys("l")
+	if m.files.preview.active {
+		t.Fatal("l on a file should not preview")
+	}
+
+	selectFilesEntry(m, "nested")
+	m.updateFilesKeys("enter")
+	if m.files.panes[0].cwd != sub {
+		t.Fatalf("enter on dir should cd, cwd=%q", m.files.panes[0].cwd)
+	}
+}
+
+func TestFilesPreviewStaleMsgIgnored(t *testing.T) {
+	m := testApp(t)
+	_ = m.enterFilesSection()
+	m.files.preview = filesPreview{active: true, gen: 2, path: "/tmp/x"}
+	m.Update(filesPreviewMsg{gen: 1, preview: files.Preview{Text: "stale"}})
+	if m.files.preview.result.Text == "stale" {
+		t.Fatal("stale preview msg should be ignored")
+	}
+	m.files.preview.active = false
+	m.Update(filesPreviewMsg{gen: 2, preview: files.Preview{Text: "late"}})
+	if m.files.preview.result.Text == "late" {
+		t.Fatal("inactive preview msg should be ignored")
+	}
+}
+
+func TestFilesPreviewWalkNextFile(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+	selectFilesEntry(m, "a.txt")
+	applyFilesPreview(t, m)
+	if m.files.preview.result.Text != "aaa" {
+		t.Fatalf("a.txt text = %q", m.files.preview.result.Text)
+	}
+	_, cmd := m.updateFilesPreview("]")
+	if cmd != nil {
+		m.Update(cmd())
+	}
+	if m.files.panes[0].entries[m.files.panes[0].cursor].Name != "b.txt" {
+		t.Fatalf("] should skip directory and land on b.txt, cursor=%q", m.files.panes[0].entries[m.files.panes[0].cursor].Name)
+	}
+	if m.files.preview.result.Text != "bbb" {
+		t.Fatalf("b.txt text = %q", m.files.preview.result.Text)
+	}
+}
+
+func TestFilesPreviewQDoesNotQuit(t *testing.T) {
+	m := testApp(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.enterFilesSection()
+	entries, err := files.ListLocal(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyFilesList(m, 0, dir, entries)
+	selectFilesEntry(m, "a.txt")
+	applyFilesPreview(t, m)
+
+	_, cmd := m.Update(press("q"))
+	if m.files.preview.active {
+		t.Fatal("q should close preview")
+	}
+	if m.section != filesSection {
+		t.Fatalf("section = %v", m.section)
+	}
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); ok {
+			t.Fatal("q should not quit while closing preview")
+		}
 	}
 }
 

--- a/apps/bast/internal/ui/keymap.go
+++ b/apps/bast/internal/ui/keymap.go
@@ -79,6 +79,8 @@ const (
 	ActionFilesRemote
 	ActionFilesParent
 	ActionFilesEnter
+	ActionFilesOpenDir
+	ActionFilesPreview
 	ActionFilesJump
 	ActionFilesPath
 	ActionFilesMark

--- a/apps/bast/internal/ui/keymap_catalog.go
+++ b/apps/bast/internal/ui/keymap_catalog.go
@@ -193,9 +193,9 @@ func buildCatalog() []Binding {
 		bind(ActionFilesRemote, []string{"R"}, ScopeFiles, "Pane remote", "").noHelp(),
 		bind(ActionNone, nil, ScopeFiles, "Pane local / remote", "").chord("L  R").helpOnly(),
 		bind(ActionFilesParent, []string{"h", "backspace", "ctrl+h"}, ScopeFiles, "Parent", "").noHelp(),
-		bind(ActionFilesEnter, []string{"l"}, ScopeFiles, "Enter", "").noHelp(),
+		bind(ActionFilesOpenDir, []string{"l"}, ScopeFiles, "Enter", "").noHelp(),
 		bind(ActionNone, nil, ScopeFiles, "Parent / enter", "").chord("h  l").helpOnly(),
-		bind(ActionFilesEnter, []string{"enter"}, ScopeFiles, "Enter dir or connect host", ""),
+		bind(ActionFilesEnter, []string{"enter"}, ScopeFiles, "Enter dir, preview file, or connect host", ""),
 		bind(ActionNone, nil, ScopeFiles, "Move / top / bottom", "").chord("j k  g G").helpOnly(),
 		bind(ActionFilesJump, []string{"f"}, ScopeFiles, "Fuzzy jump", "jump"),
 		bind(ActionFilesPath, []string{"/"}, ScopeFiles, "Path jump or host search", ""),
@@ -208,6 +208,7 @@ func buildCatalog() []Binding {
 		bind(ActionFilesMkdir, []string{"a"}, ScopeFiles, "New directory", ""),
 		bind(ActionFilesRename, []string{"r"}, ScopeFiles, "Rename", ""),
 		bind(ActionFilesInfo, []string{"i"}, ScopeFiles, "File info", ""),
+		bind(ActionFilesPreview, []string{"o"}, ScopeFiles, "Preview file", ""),
 		bind(ActionFilesChmod, []string{"p"}, ScopeFiles, "Permissions (chmod)", ""),
 		bind(ActionFilesShell, []string{"t"}, ScopeFiles, "Shell in directory", ""),
 		bind(ActionFilesHidden, []string{"."}, ScopeFiles, "Toggle hidden files", ""),
@@ -451,7 +452,7 @@ func filesFooterBrowse(m *App) bool {
 	if m.section != filesSection || !m.files.ready {
 		return false
 	}
-	if m.files.chmod.active || m.files.info || m.files.transfer.active || m.files.jump.active {
+	if m.files.chmod.active || m.files.info || m.files.preview.active || m.files.transfer.active || m.files.jump.active {
 		return false
 	}
 	pane := m.filesFocusedPane()
@@ -462,7 +463,7 @@ func filesFooterPickHost(m *App) bool {
 	if m.section != filesSection || !m.files.ready {
 		return false
 	}
-	if m.files.chmod.active || m.files.info || m.files.transfer.active || m.files.jump.active {
+	if m.files.chmod.active || m.files.info || m.files.preview.active || m.files.transfer.active || m.files.jump.active {
 		return false
 	}
 	pane := m.filesFocusedPane()

--- a/apps/bast/internal/ui/keymap_dispatch.go
+++ b/apps/bast/internal/ui/keymap_dispatch.go
@@ -206,6 +206,12 @@ func (m *App) dispatch(id Action) (tea.Model, tea.Cmd) {
 	case ActionFilesEnter:
 		m.initFilesState()
 		return m.activateFilesSelection()
+	case ActionFilesOpenDir:
+		m.initFilesState()
+		return m.enterFilesDirectory()
+	case ActionFilesPreview:
+		m.initFilesState()
+		return m.openFilesPreview()
 	case ActionFilesJump:
 		m.initFilesState()
 		return m.beginFilesJump()
@@ -587,7 +593,7 @@ func (m *App) filesOverlay() bool {
 		return false
 	}
 	m.initFilesState()
-	if m.files.chmod.active || m.files.info || m.files.transfer.active || m.files.jump.active {
+	if m.files.chmod.active || m.files.info || m.files.preview.active || m.files.transfer.active || m.files.jump.active {
 		return true
 	}
 	pane := m.filesFocusedPane()

--- a/apps/bast/internal/ui/keymap_test.go
+++ b/apps/bast/internal/ui/keymap_test.go
@@ -74,6 +74,20 @@ func TestHelpUpScrollsUpNotDown(t *testing.T) {
 	}
 }
 
+func TestFilesPreviewAndOpenDirBindings(t *testing.T) {
+	m := testApp(t)
+	m.section = filesSection
+	if b, ok := m.matchBinding("o"); !ok || b.ID != ActionFilesPreview {
+		t.Fatalf("files o = %+v ok=%v", b, ok)
+	}
+	if b, ok := m.matchBinding("l"); !ok || b.ID != ActionFilesOpenDir {
+		t.Fatalf("files l = %+v ok=%v", b, ok)
+	}
+	if b, ok := m.matchBinding("enter"); !ok || b.ID != ActionFilesEnter {
+		t.Fatalf("files enter = %+v ok=%v", b, ok)
+	}
+}
+
 func TestDoctorKeyDoesNotStealFilesDisconnect(t *testing.T) {
 	m := testApp(t)
 	if b, ok := m.matchBinding("D"); !ok || b.ID != ActionDoctorOpen {

--- a/apps/web/components/tui-demo.tsx
+++ b/apps/web/components/tui-demo.tsx
@@ -410,6 +410,15 @@ const localFiles: FileEntry[] = [
   },
 ];
 
+const filePreviewBodies: Record<string, string> = {
+  "notes.md":
+    "# roll\n\napi first\njump box last\nkeep secrets out of git\ncheck health after deploy\nrevert on 5xx\nwrite the postmortem",
+  "secret.env": "REGION=us-east-1\nLOG_LEVEL=info\nKEEPALIVE=30",
+  "id_ed25519.pub": "ssh-ed25519 AAAAC3… work",
+};
+
+const previewVisibleLines = 5;
+
 const remoteFiles: FileEntry[] = [
   {
     name: "app",
@@ -551,6 +560,8 @@ export function TuiDemo() {
     "secret.env": true,
   });
   const [filesInfo, setFilesInfo] = useState(false);
+  const [filesPreview, setFilesPreview] = useState(false);
+  const [previewOffset, setPreviewOffset] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const hostRows = useMemo(() => buildHostRows(collapsed), [collapsed]);
@@ -575,6 +586,8 @@ export function TuiDemo() {
 
   const switchSection = useCallback((next: Section) => {
     setSection(next);
+    setFilesPreview(false);
+    setPreviewOffset(0);
     if (next === "sync") {
       setSyncProvider("");
       setSyncCursor(0);
@@ -643,6 +656,60 @@ export function TuiDemo() {
     [filesFocus],
   );
 
+  const focusedFilesEntry = useCallback(() => {
+    const entries = filesFocus === 0 ? localFiles : remoteFiles;
+    const cursor = filesFocus === 0 ? safeLocalCursor : safeRemoteCursor;
+    return entries[cursor];
+  }, [filesFocus, safeLocalCursor, safeRemoteCursor]);
+
+  const toggleFilesPreview = useCallback(() => {
+    const entry = focusedFilesEntry();
+    if (!entry || entry.isDir) return;
+    setFilesInfo(false);
+    setFilesPreview((open) => {
+      if (!open) {
+        setPreviewOffset(0);
+      }
+      return !open;
+    });
+  }, [focusedFilesEntry]);
+
+  const scrollFilesPreview = useCallback(
+    (delta: number) => {
+      const entry = focusedFilesEntry();
+      const body = entry ? (filePreviewBodies[entry.name] ?? "") : "";
+      const lineCount = body === "" ? 0 : body.split("\n").length;
+      const maxOffset = Math.max(0, lineCount - previewVisibleLines);
+      setPreviewOffset((current) =>
+        Math.max(0, Math.min(maxOffset, current + delta)),
+      );
+    },
+    [focusedFilesEntry],
+  );
+
+  const stepFilesPreview = useCallback(
+    (delta: number) => {
+      const entries = filesFocus === 0 ? localFiles : remoteFiles;
+      const cursor = filesFocus === 0 ? safeLocalCursor : safeRemoteCursor;
+      const setCursor = filesFocus === 0 ? setLocalCursor : setRemoteCursor;
+      for (let i = 1; i < entries.length; i += 1) {
+        const idx = cursor + delta * i;
+        if (idx < 0 || idx >= entries.length) {
+          return;
+        }
+        if (entries[idx].isDir) {
+          continue;
+        }
+        setCursor(idx);
+        setPreviewOffset(0);
+        setFilesInfo(false);
+        setFilesPreview(true);
+        return;
+      }
+    },
+    [filesFocus, safeLocalCursor, safeRemoteCursor],
+  );
+
   const toggleFilesMark = useCallback(() => {
     if (filesFocus !== 0) return;
     const entry = localFiles[safeLocalCursor];
@@ -683,6 +750,7 @@ export function TuiDemo() {
           event.preventDefault();
           if (section === "hosts") moveHosts(1);
           else if (section === "keys") moveKeys(1);
+          else if (section === "files" && filesPreview) scrollFilesPreview(1);
           else if (section === "files") moveFiles(1);
           else if (section === "vault") moveVault(1);
           else moveSync(1);
@@ -692,9 +760,22 @@ export function TuiDemo() {
           event.preventDefault();
           if (section === "hosts") moveHosts(-1);
           else if (section === "keys") moveKeys(-1);
+          else if (section === "files" && filesPreview) scrollFilesPreview(-1);
           else if (section === "files") moveFiles(-1);
           else if (section === "vault") moveVault(-1);
           else moveSync(-1);
+          break;
+        case "[":
+          if (section === "files" && filesPreview) {
+            event.preventDefault();
+            stepFilesPreview(-1);
+          }
+          break;
+        case "]":
+          if (section === "files" && filesPreview) {
+            event.preventDefault();
+            stepFilesPreview(1);
+          }
           break;
         case "h":
         case "ArrowLeft":
@@ -745,17 +826,34 @@ export function TuiDemo() {
         case "i":
           if (section === "files") {
             event.preventDefault();
+            setFilesPreview(false);
+            setPreviewOffset(0);
             setFilesInfo((current) => !current);
           }
           break;
+        case "o":
+          if (section === "files") {
+            event.preventDefault();
+            toggleFilesPreview();
+          }
+          break;
         case "Enter":
+          event.preventDefault();
+          if (section === "hosts" && selectedHostRow?.kind === "group") {
+            toggleGroup(selectedHostRow.id);
+          } else if (section === "sync") {
+            activateSync();
+          } else if (section === "files") {
+            toggleFilesPreview();
+          }
+          break;
         case " ":
           event.preventDefault();
           if (section === "hosts" && selectedHostRow?.kind === "group") {
             toggleGroup(selectedHostRow.id);
           } else if (section === "sync") {
             activateSync();
-          } else if (section === "files" && event.key === " ") {
+          } else if (section === "files" && !filesPreview) {
             toggleFilesMark();
           }
           break;
@@ -764,6 +862,10 @@ export function TuiDemo() {
             event.preventDefault();
             setSyncProvider("");
             setSyncCursor(0);
+          } else if (section === "files" && filesPreview) {
+            event.preventDefault();
+            setFilesPreview(false);
+            setPreviewOffset(0);
           } else if (section === "files" && filesInfo) {
             event.preventDefault();
             setFilesInfo(false);
@@ -777,8 +879,11 @@ export function TuiDemo() {
     [
       activateSync,
       filesInfo,
+      filesPreview,
       localMarked,
       moveFiles,
+      scrollFilesPreview,
+      stepFilesPreview,
       moveHosts,
       moveKeys,
       moveSync,
@@ -790,6 +895,7 @@ export function TuiDemo() {
       switchSection,
       syncProvider,
       toggleFilesMark,
+      toggleFilesPreview,
       toggleGroup,
     ],
   );
@@ -800,9 +906,11 @@ export function TuiDemo() {
       : section === "keys"
         ? "g generate • i import • x export • a add to server • ? help"
         : section === "files"
-          ? filesInfo
-            ? "j/k next • i/esc close"
-            : "tab pane • ␣ mark • i info • p chmod • ? help"
+          ? filesPreview
+            ? "j/k scroll • [ ] file • o/esc close"
+            : filesInfo
+              ? "j/k next • i/esc close"
+              : "tab pane • ␣ mark • o preview • i info • ? help"
           : section === "vault"
             ? "↵ action • 4 sync • ? help"
             : syncProvider
@@ -815,9 +923,11 @@ export function TuiDemo() {
       : section === "keys"
         ? "tap select • 1/2/3/4/5 tabs"
         : section === "files"
-          ? filesInfo
-            ? "i/esc close • 1/2/3/4/5 tabs"
-            : "tap pane • i info • 1/2/3/4/5 tabs"
+          ? filesPreview
+            ? "o/esc close • 1/2/3/4/5 tabs"
+            : filesInfo
+              ? "i/esc close • 1/2/3/4/5 tabs"
+              : "tap pane • o preview • i info • 1/2/3/4/5 tabs"
           : section === "vault"
             ? "tap action • 1/2/3/4/5 tabs"
             : "tap provider • 1/2/3/4/5 tabs";
@@ -911,6 +1021,8 @@ export function TuiDemo() {
           remoteCursor={safeRemoteCursor}
           localMarked={localMarked}
           info={filesInfo}
+          preview={filesPreview}
+          previewOffset={previewOffset}
           onFocus={setFilesFocus}
           onSelectLocal={setLocalCursor}
           onSelectRemote={setRemoteCursor}
@@ -925,7 +1037,11 @@ export function TuiDemo() {
               return next;
             });
           }}
-          onToggleInfo={() => setFilesInfo((current) => !current)}
+          onToggleInfo={() => {
+            setFilesPreview(false);
+            setFilesInfo((current) => !current);
+          }}
+          onTogglePreview={toggleFilesPreview}
           footerDesktop={footerHintDesktop}
           footerMobile={footerHintMobile}
         />
@@ -1041,11 +1157,14 @@ function FilesPanel({
   remoteCursor,
   localMarked,
   info,
+  preview,
+  previewOffset,
   onFocus,
   onSelectLocal,
   onSelectRemote,
   onToggleMark,
   onToggleInfo,
+  onTogglePreview,
   footerDesktop,
   footerMobile,
 }: {
@@ -1054,16 +1173,21 @@ function FilesPanel({
   remoteCursor: number;
   localMarked: Record<string, boolean>;
   info: boolean;
+  preview: boolean;
+  previewOffset: number;
   onFocus: (pane: 0 | 1) => void;
   onSelectLocal: (index: number) => void;
   onSelectRemote: (index: number) => void;
   onToggleMark: (name: string) => void;
   onToggleInfo: () => void;
+  onTogglePreview: () => void;
   footerDesktop: string;
   footerMobile: string;
 }) {
+  const previewEntry =
+    focus === 0 ? localFiles[localCursor] : remoteFiles[remoteCursor];
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="relative flex min-h-0 flex-1 flex-col">
       <div className={`h-px shrink-0 bg-border ${bleedMargin}`} />
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 pt-2 md:hidden">
@@ -1141,7 +1265,48 @@ function FilesPanel({
       <footer className="mt-2 shrink-0 truncate text-right text-[10px] text-muted sm:text-xs md:hidden">
         {footerMobile}
       </footer>
+
+      {preview && previewEntry && !previewEntry.isDir ? (
+        <FilesPreview
+          entry={previewEntry}
+          offset={previewOffset}
+          onClose={onTogglePreview}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function FilesPreview({
+  entry,
+  offset,
+  onClose,
+}: {
+  entry: FileEntry;
+  offset: number;
+  onClose: () => void;
+}) {
+  const kind = entry.name.endsWith(".json") ? "json" : "text";
+  const body = filePreviewBodies[entry.name] ?? "";
+  const lines = body === "" ? [] : body.split("\n");
+  const visible = lines.slice(offset, offset + previewVisibleLines);
+  const title = `${entry.name} · ${kind} · ${entry.size}`;
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      className="absolute inset-0 z-20 flex cursor-pointer items-center justify-center border-0 bg-transparent p-3 font-[inherit] text-left"
+      aria-label="Close preview"
+    >
+      <div className="max-h-[80%] w-[min(100%,28rem)] overflow-hidden rounded-md border border-border bg-background px-3 py-2">
+        <p className="truncate font-bold text-accent">{title}</p>
+        {visible.length > 0 ? (
+          <pre className="mt-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-foreground">
+            {visible.join("\n")}
+          </pre>
+        ) : null}
+      </div>
+    </button>
   );
 }
 

--- a/apps/web/content/docs/features/(hosts)/files.mdx
+++ b/apps/web/content/docs/features/(hosts)/files.mdx
@@ -61,12 +61,25 @@ Copy and move always target the **other** pane’s current directory.
 | `a` | Create directory |
 | `r` | Rename |
 | `i` | File info (name, type, size, mode) |
+| `o` | Preview the cursor file (text, JSON, PDF) |
 | `p` | Change permissions (chmod) on local or remote items |
 | `esc` / `x` | Cancel an in-progress transfer |
 
 ### File info
 
 Press `i` on the cursor row. The focused pane shows name, type, size, mode (octal and symbolic), and modified time. `j`/`k` move to the next or previous item while info stays open. `p` jumps into the permissions editor. `i` or `Esc` closes.
+
+### Preview
+
+Press `o`, or Enter on a file. A floating panel shows the contents. Text and JSON are shown as text (JSON is indented). PDFs show extracted text, not rendered pages. Images and binaries show type and size only.
+
+| Key | Action |
+| --- | --- |
+| `j` / `k` | Scroll |
+| `[` / `]` | Previous / next file |
+| `o` / `Esc` / `q` | Close |
+
+`l` still enters directories only. Space still marks. Preview reads a prefix of text files (512 KB) and will not download PDFs larger than 8 MB.
 
 ### Permissions
 
@@ -98,7 +111,6 @@ Deferred for later:
 - Directory sync / mirror
 - Trash / undo
 - chown UI
-- Inline previews
 - Shared ControlMaster connections
 
 ## Native OpenSSH

--- a/apps/web/content/docs/features/(other)/shortcuts.mdx
+++ b/apps/web/content/docs/features/(other)/shortcuts.mdx
@@ -91,7 +91,7 @@ See [GCP](/docs/features/gcp) / [AWS](/docs/features/aws) / [Azure](/docs/featur
 | `w` | Swap panes |
 | `L` / `R` | Make focused pane local / remote |
 | `h` / `l` | Parent / enter directory |
-| `Enter` | Enter directory, or connect the selected host |
+| `Enter` | Enter directory, preview a file, or connect the selected host |
 | `j` / `k` | Move |
 | `g` / `G` | Top / bottom |
 | `f` | Fuzzy jump |
@@ -103,6 +103,7 @@ See [GCP](/docs/features/gcp) / [AWS](/docs/features/aws) / [Azure](/docs/featur
 | `a` | Create directory |
 | `r` | Rename |
 | `i` | File info |
+| `o` | Preview file |
 | `p` | Permissions (chmod) |
 | `t` | Open a shell in the current directory |
 | `.` | Toggle hidden files |


### PR DESCRIPTION
closes #67

Files tab preview: `o` or Enter on a file opens a floating peek at text, JSON, and PDF contents. Space stays mark. `j`/`k` scroll, `[`/`]` walk files, Esc closes.

Reads are capped (512 KB text prefix, 8 MB for PDFs). Images and binaries show type and size only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ellipse-software/codesmith/bast/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790172654&installation_model_id=433795&pr_number=84&repository=ellipse-software%2Fbast&return_to=https%3A%2F%2Fgithub.com%2Fellipse-software%2Fbast%2Fpull%2F84&signature=e860ecbcc8487aac759edb311227307cacb1bb68982b46cd20d949340e4f8479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added file previews in the Files section for text, JSON, and PDF files.
  - Images and binary files now show metadata without loading file contents.
  - Open previews with `o` or Enter, navigate between files, scroll content, and close with Escape or `q`.
  - Added loading, error, truncation, directory, and remote-file handling.
- **Documentation**
  - Documented preview behavior, file type support, size limits, navigation, and keyboard shortcuts.
  - Added the `o` shortcut to the Files help and shortcuts documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->