### PR TITLE
feat: bast doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ User-facing changes to Bast (CLI, installers, and behaviour). Website-only chang
 
 ### Added
 
+- `bast doctor` diagnoses SSH config, keys, permissions, and Bast setup. Press `D` in the TUI (not in Files). `--fix` repairs the Bast Include and modes OpenSSH will refuse; `--json` exposes stable finding ids.
+- `bast doctor` uses the TUI palette on a color terminal (purple headers, red failures, green ok findings). Pipes and `NO_COLOR` stay plain.
 - Shell completions via `bast completion` for bash, zsh, fish, PowerShell, Elvish, and Nushell. Tab completes commands, flags, hosts, and keys. The script installers enable this automatically (opt out with `BAST_NO_COMPLETIONS=1`). Homebrew generates bash, zsh, and fish completions on install.
 - Script installers accept `BAST_VERSION` (stable) and `BAST_NIGHTLY_VERSION` (nightly) to install a specific GitHub release.
 - Keys tab: `g` generates a key, `a` adds the selected key to a server. The in-app `?` overlay, footer hints, and detail chips share one keymap.
 - Homebrew formulae compile Bast from source instead of installing prebuilt release archives.
+
+### Fixed
+
+- `bast doctor` finds the ASCII Box CLI at `~/.ascii/bin/box` the same way Bast sync does, instead of reporting it missing when `box` is only a shell function.
 
 ## v0.9.3 - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ Then run `bast`. Nightly builds, custom install paths, and building from source 
 ```sh
 bast                    # host picker
 bast production         # connect by label
+bast doctor             # diagnose SSH config and setup
 bast hosts list         # list hosts
 bast keys list          # list keys
 ```
 
-Press `?` in the TUI for keybindings. [Documentation](https://bast.sh/docs) covers hosts, keys, Vault, cloud sync, Files, and the CLI.
+Press `?` in the TUI for keybindings. [Documentation](https://bast.sh/docs) covers hosts, keys, Vault, cloud sync, Files, doctor, and the CLI.
 
 ## Agent skill
 

--- a/apps/bast/internal/cli/cli.go
+++ b/apps/bast/internal/cli/cli.go
@@ -33,6 +33,7 @@ Usage:
   bast <label>                 Connect directly using a host label
   bast tui                     Open the TUI explicitly
   bast update                  Update script-installed copies of Bast
+  bast doctor                  Diagnose SSH config, keys, and Bast setup
   bast connect <host>          Connect using an alias or display label
   bast hosts <command>         Manage SSH hosts
   bast keys <command>          Manage SSH keys
@@ -66,9 +67,9 @@ Global options:
   --json                      Emit structured JSON
   --no-input                  Never prompt for missing input
 
-Run "bast hosts <command> --help", "bast keys <command> --help", "bast sync <command> --help",
-"bast box <command> --help", "bast upstash <command> --help", "bast vault <command> --help",
-or "bast completion --help" for details.
+Run "bast doctor --help", "bast hosts <command> --help", "bast keys <command> --help",
+"bast sync <command> --help", "bast box <command> --help", "bast upstash <command> --help",
+"bast vault <command> --help", or "bast completion --help" for details.
 `
 
 func PrintHelp(out io.Writer) { fmt.Fprint(out, help) }
@@ -92,6 +93,10 @@ type Runner struct {
 type reportedError struct{ code int }
 
 func (e reportedError) Error() string { return "CLI error already reported" }
+
+type silentExit struct{ code int }
+
+func (e silentExit) Error() string { return "silent exit" }
 func ExitCode(err error) (int, bool) {
 	var reported reportedError
 	ok := errors.As(err, &reported)
@@ -122,7 +127,7 @@ func New(p paths.Paths, client openssh.Client, in io.Reader, out, errOut io.Writ
 
 func IsCommand(arg string) bool {
 	switch arg {
-	case "tui", "update", "connect", "hosts", "keys", "sync", "box", "upstash", "vault", "completion", "__complete":
+	case "tui", "update", "doctor", "connect", "hosts", "keys", "sync", "box", "upstash", "vault", "completion", "__complete":
 		return true
 	}
 	return false
@@ -163,6 +168,8 @@ func (r *Runner) Run(args []string) error {
 	var err error
 	if args[0] == "update" {
 		err = r.update(args[1:])
+	} else if args[0] == "doctor" {
+		err = r.doctor(args[1:])
 	} else {
 		store, openErr := metadata.Open(r.Paths.StateFile)
 		err = openErr
@@ -198,6 +205,10 @@ func (r *Runner) report(err error) error {
 	if err == nil {
 		return nil
 	}
+	var silent silentExit
+	if errors.As(err, &silent) {
+		return reportedError{code: silent.code}
+	}
 	ce := &commandError{code: "operation_failed", message: err.Error(), exit: 1}
 	var typed *commandError
 	if errors.As(err, &typed) {
@@ -224,6 +235,7 @@ func (r *Runner) report(err error) error {
 func commandUsage(resource, command string) string {
 	usage := map[string]string{
 		"update --help": "Usage: bast update",
+		"doctor --help": "Usage: bast doctor [--fix] [--probe] [--category name]",
 		"hosts --help": `Usage: bast hosts <command>
 
 Commands: list, show, add, edit, delete, promote, favorite, unfavorite, hide,

--- a/apps/bast/internal/cli/cli_test.go
+++ b/apps/bast/internal/cli/cli_test.go
@@ -174,7 +174,7 @@ func TestKeyCommandsImportEditExportAndDelete(t *testing.T) {
 }
 
 func TestInvocationAndCommandHelp(t *testing.T) {
-	if !IsInvocation([]string{"--json", "hosts", "list"}) || !IsInvocation([]string{"connect", "prod"}) || !IsInvocation([]string{"update"}) || !IsInvocation([]string{"completion", "bash"}) || IsInvocation([]string{"prod"}) {
+	if !IsInvocation([]string{"--json", "hosts", "list"}) || !IsInvocation([]string{"connect", "prod"}) || !IsInvocation([]string{"update"}) || !IsInvocation([]string{"doctor"}) || !IsInvocation([]string{"completion", "bash"}) || IsInvocation([]string{"prod"}) {
 		t.Fatal("command invocation detection is incorrect")
 	}
 	out, errOut, err := runTestCLI(t, t.TempDir(), fakeOpenSSH(t), "hosts", "add", "--help")
@@ -237,6 +237,10 @@ func fakeOpenSSH(t *testing.T) openssh.Client {
 		return path
 	}
 	ssh := writeScript("ssh", `
+if [ "$1" = "-V" ]; then
+  echo OpenSSH_9.8p1 >&2
+  exit 0
+fi
 if [ "$1" = "-G" ]; then
   printf 'hostname resolved.example\nuser deploy\nport 22\nidentitiesonly no\npubkeyauthentication yes\npasswordauthentication yes\nproxyjump none\n'
   exit 0
@@ -249,6 +253,31 @@ if [ "$1" = "-y" ]; then printf 'ssh-ed25519 AAA-test derived\n'; exit 0; fi
 exit 0`)
 	sshAdd := writeScript("ssh-add", "exit 1")
 	return openssh.Client{SSH: ssh, SSHKeygen: keygen, SSHAdd: sshAdd}
+}
+
+func TestDoctorJSONReportsIncludeScoping(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(filepath.Join(sshDir, "bast"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "bast", "config"), []byte("Host managed\n  HostName managed.example\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "config"), []byte("Host work\n  HostName work.example\n  Include ~/.ssh/bast/config\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	out, errOut, err := runTestCLI(t, home, fakeOpenSSH(t), "--json", "doctor")
+	code, ok := ExitCode(err)
+	if !ok || code != 1 {
+		t.Fatalf("expected exit 1, err=%v stderr=%q", err, errOut)
+	}
+	if errOut != "" {
+		t.Fatalf("stderr=%q", errOut)
+	}
+	if !strings.Contains(out, `"ok":true`) || !strings.Contains(out, `"healthy":false`) || !strings.Contains(out, "ssh_config.include_not_toplevel") {
+		t.Fatalf("output=%q", out)
+	}
 }
 
 func TestVaultLoginRequiresAcceptTerms(t *testing.T) {

--- a/apps/bast/internal/cli/doctor.go
+++ b/apps/bast/internal/cli/doctor.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"bast/internal/doctor"
+	"bast/internal/telemetry"
+)
+
+func (r *Runner) doctor(args []string) error {
+	fs := newFlagSet("doctor")
+	fix := fs.Bool("fix", false, "")
+	probe := fs.Bool("probe", false, "")
+	var categories stringsFlag
+	fs.Var(&categories, "category", "")
+	if err := fs.Parse(args); err != nil {
+		return usagef("%v", err)
+	}
+	if fs.NArg() != 0 {
+		return usagef("usage: bast doctor [--fix] [--probe] [--category name]")
+	}
+	for _, c := range categories {
+		if !doctor.ValidCategory(c) {
+			return usagef("unknown doctor category %q", c)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	eng := doctor.New(r.Paths, r.OpenSSH, r.Version)
+	report := eng.Run(ctx, doctor.Options{Fix: *fix, Probe: *probe, Categories: []string(categories)})
+	telemetry.Track("doctor", r.Version)
+	if r.JSON {
+		if err := r.success(report, ""); err != nil {
+			return err
+		}
+	} else if err := doctor.Format(r.Out, report); err != nil {
+		return err
+	}
+	if report.HasFail() {
+		return silentExit{code: 1}
+	}
+	return nil
+}

--- a/apps/bast/internal/doctor/check_agent.go
+++ b/apps/bast/internal/doctor/check_agent.go
@@ -1,0 +1,46 @@
+package doctor
+
+import "runtime"
+
+func (e Engine) checkAgent(r *Report, st runState) {
+	ag := st.agent
+	if !ag.checked {
+		return
+	}
+	switch {
+	case ag.present && ag.count > 0:
+		title := "ssh-agent is running"
+		if ag.count == 1 {
+			title = "ssh-agent is running with 1 key"
+		} else {
+			title = "ssh-agent is running with keys"
+		}
+		r.add(Finding{ID: "agent.ok", Severity: SeverityOK, Category: CatAgent, Title: title})
+		if ag.count >= 6 {
+			r.add(Finding{
+				ID: "agent.many_keys", Severity: SeverityWarn, Category: CatAgent,
+				Title:  "ssh-agent holds many keys",
+				Detail: "Servers often allow only a few attempts. Set IdentitiesOnly yes on hosts that pin an IdentityFile.",
+			})
+		}
+	case ag.present && ag.empty:
+		r.add(Finding{
+			ID: "agent.empty", Severity: SeverityInfo, Category: CatAgent,
+			Title: "ssh-agent is running with no keys",
+			Fix:   "ssh-add --apple-use-keychain ~/.ssh/id_ed25519  (macOS) or ssh-add <key>",
+		})
+	default:
+		detail := ag.err
+		if detail == "" {
+			detail = "Passphrase-protected keys will prompt on every connect."
+		}
+		fix := "eval \"$(ssh-agent -s)\" then ssh-add"
+		if runtime.GOOS == "windows" {
+			fix = "Start the OpenSSH Authentication Agent service, then ssh-add."
+		}
+		r.add(Finding{
+			ID: "agent.missing", Severity: SeverityWarn, Category: CatAgent,
+			Title: "ssh-agent is not running", Detail: detail, Fix: fix,
+		})
+	}
+}

--- a/apps/bast/internal/doctor/check_config.go
+++ b/apps/bast/internal/doctor/check_config.go
@@ -1,0 +1,393 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"bast/internal/sshconfig"
+)
+
+func (e Engine) checkConfig(r *Report, st runState) {
+	ins := st.ins
+	if len(ins.Files) == 1 && ins.Files[0].Missing {
+		r.add(Finding{
+			ID: "ssh_config.missing", Severity: SeverityInfo, Category: CatSSHConfig,
+			Title: "No ~/.ssh/config yet", Path: e.display(e.Paths.MainConfig),
+			Detail: "Bast will create one and add Include ~/.ssh/bast/config when you add a managed host.",
+			Fix:    "Run bast doctor --fix to create the Bast include now.", Fixable: true,
+		})
+		return
+	}
+	for _, file := range ins.Files {
+		if file.Missing {
+			continue
+		}
+		if file.BOM {
+			r.add(Finding{
+				ID: "ssh_config.bom", Severity: SeverityWarn, Category: CatSSHConfig,
+				Title: "UTF-8 BOM at start of config", Path: e.display(file.Path),
+				Detail: "A byte-order mark can make the first directive fail to parse.",
+			})
+		}
+		if file.CRLF && runtime.GOOS != "windows" {
+			r.add(Finding{
+				ID: "ssh_config.crlf", Severity: SeverityWarn, Category: CatSSHConfig,
+				Title: "CRLF line endings", Path: e.display(file.Path),
+				Detail: "Unix OpenSSH expects LF line endings.",
+			})
+		}
+	}
+	for _, err := range ins.ParseErrors {
+		sev := SeverityFail
+		if err.Code == "parse" {
+			sev = SeverityWarn
+		}
+		r.add(Finding{
+			ID: "ssh_config." + err.Code, Severity: sev, Category: CatSSHConfig,
+			Title: err.Message, Path: e.display(err.Path), Line: err.Line, Detail: err.Message,
+		})
+	}
+	e.checkBastInclude(r, ins)
+	e.checkSyncIncludes(r, ins, st)
+	e.checkEmptyIncludes(r, ins)
+	e.checkDuplicateAliases(r, ins)
+	e.checkMatchAndWildcards(r, ins)
+	e.checkHosts(r, ins, st)
+}
+
+func (e Engine) checkBastInclude(r *Report, ins sshconfig.Inspection) {
+	var top, scoped []sshconfig.InspectInclude
+	for _, inc := range ins.Includes {
+		if !e.includeIs(inc, e.Paths.ManagedConfig) {
+			continue
+		}
+		if inc.TopLevel && filepath.Clean(inc.Source) == filepath.Clean(e.Paths.MainConfig) {
+			top = append(top, inc)
+		} else {
+			scoped = append(scoped, inc)
+		}
+	}
+	managedHasHosts := false
+	if b, err := os.ReadFile(e.Paths.ManagedConfig); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			fields := strings.Fields(strings.TrimSpace(line))
+			if len(fields) >= 2 && strings.EqualFold(fields[0], "host") {
+				managedHasHosts = true
+				break
+			}
+		}
+	}
+	switch {
+	case len(top) == 0 && len(scoped) > 0:
+		inc := scoped[0]
+		r.add(Finding{
+			ID: "ssh_config.include_not_toplevel", Severity: SeverityFail, Category: CatSSHConfig,
+			Title: "Include ~/.ssh/bast/config is inside a Host or Match block",
+			Path:  e.display(inc.Source), Line: inc.Line, Host: inc.Scope,
+			Detail:  "OpenSSH treats that Include as part of the preceding Host/Match, so Bast-managed hosts never apply.",
+			Fix:     "Move Include ~/.ssh/bast/config to the top of ~/.ssh/config, before any Host or Match block.",
+			Fixable: true,
+		})
+	case len(top) == 0 && managedHasHosts:
+		r.add(Finding{
+			ID: "ssh_config.include_missing", Severity: SeverityFail, Category: CatSSHConfig,
+			Title: "Bast Include is missing from ~/.ssh/config", Path: e.display(e.Paths.MainConfig),
+			Detail:  "Managed hosts in ~/.ssh/bast/config are not visible to OpenSSH.",
+			Fix:     "Add Include ~/.ssh/bast/config at the top of ~/.ssh/config.",
+			Fixable: true,
+		})
+	case len(top) == 0:
+		r.add(Finding{
+			ID: "ssh_config.include_missing", Severity: SeverityInfo, Category: CatSSHConfig,
+			Title: "Bast Include is not in ~/.ssh/config yet", Path: e.display(e.Paths.MainConfig),
+			Detail:  "Bast prepends Include ~/.ssh/bast/config on first managed write.",
+			Fix:     "Run bast doctor --fix to add it now.",
+			Fixable: true,
+		})
+	default:
+		if len(top) > 1 {
+			r.add(Finding{
+				ID: "ssh_config.include_duplicate", Severity: SeverityWarn, Category: CatSSHConfig,
+				Title: "Bast Include appears more than once", Path: e.display(top[1].Source), Line: top[1].Line,
+				Detail: "Duplicate Include lines are harmless but noisy.",
+			})
+		} else {
+			r.add(Finding{
+				ID: "ssh_config.include_ok", Severity: SeverityOK, Category: CatSSHConfig,
+				Title: "Include ~/.ssh/bast/config is at the top of ~/.ssh/config",
+				Path:  e.display(top[0].Source), Line: top[0].Line,
+			})
+		}
+		if len(scoped) > 0 {
+			inc := scoped[0]
+			r.add(Finding{
+				ID: "ssh_config.include_scoped_duplicate", Severity: SeverityWarn, Category: CatSSHConfig,
+				Title: "A second Bast Include sits inside a Host or Match block",
+				Path:  e.display(inc.Source), Line: inc.Line, Host: inc.Scope,
+				Detail: "The top-level Include is enough. The Host-scoped copy is confusing and does not replace it.",
+			})
+		}
+	}
+}
+
+func (e Engine) checkSyncIncludes(r *Report, ins sshconfig.Inspection, st runState) {
+	targets := []struct {
+		path string
+		name string
+	}{
+		{e.Paths.SyncGCPConfig, "gcp"},
+		{e.Paths.SyncAWSConfig, "aws"},
+		{e.Paths.SyncAzureConfig, "azure"},
+		{e.Paths.SyncBoxConfig, "box"},
+		{e.Paths.SyncUpstashConfig, "upstash"},
+	}
+	enabled := map[string]bool{}
+	if st.store != nil {
+		enabled["gcp"] = st.store.GCP().Enabled
+		enabled["aws"] = st.store.AWS().Enabled
+		enabled["azure"] = st.store.Azure().Enabled
+		enabled["box"] = st.store.Box().Enabled
+		enabled["upstash"] = st.store.Upstash().Enabled
+	}
+	for _, t := range targets {
+		var found []sshconfig.InspectInclude
+		for _, inc := range ins.Includes {
+			if e.includeIs(inc, t.path) {
+				found = append(found, inc)
+			}
+		}
+		if len(found) == 0 {
+			continue
+		}
+		leading := false
+		for _, inc := range found {
+			if inc.TopLevel && filepath.Clean(inc.Source) == filepath.Clean(e.Paths.ManagedConfig) {
+				leading = true
+			}
+		}
+		if !leading {
+			inc := found[0]
+			r.add(Finding{
+				ID: "ssh_config.sync_include_not_leading", Severity: SeverityFail, Category: CatSSHConfig,
+				Title: "Sync Include for " + t.name + " is not at the start of ~/.ssh/bast/config",
+				Path:  e.display(inc.Source), Line: inc.Line,
+				Detail: "Include must come before any Host or Match block or synced hosts never apply.",
+			})
+		}
+		if st.store != nil && !enabled[t.name] {
+			inc := found[0]
+			r.add(Finding{
+				ID: "sync.include_orphaned", Severity: SeverityWarn, Category: CatSync,
+				Title: t.name + " sync Include is present while sync is disabled",
+				Path:  e.display(inc.Source), Line: inc.Line,
+				Detail: "Disconnecting a provider should remove its Include. Disable again from bast sync disable " + t.name + ".",
+			})
+		}
+	}
+}
+
+func (e Engine) checkEmptyIncludes(r *Report, ins sshconfig.Inspection) {
+	for _, inc := range ins.Includes {
+		if inc.Empty && !inc.Cycle && !inc.Deep {
+			r.add(Finding{
+				ID: "ssh_config.include_empty", Severity: SeverityWarn, Category: CatSSHConfig,
+				Title: "Include matched no files", Path: e.display(inc.Source), Line: inc.Line,
+				Detail: "Pattern " + inc.Pattern + " expanded to " + e.display(inc.Expanded) + ".",
+			})
+		}
+	}
+}
+
+func (e Engine) checkDuplicateAliases(r *Report, ins sshconfig.Inspection) {
+	index := map[string][]sshconfig.InspectHost{}
+	for _, h := range ins.Hosts {
+		if h.Wildcard {
+			continue
+		}
+		index[h.Alias] = append(index[h.Alias], h)
+	}
+	names := make([]string, 0, len(index))
+	for alias := range index {
+		names = append(names, alias)
+	}
+	sort.Strings(names)
+	for _, alias := range names {
+		copies := index[alias]
+		if len(copies) < 2 {
+			continue
+		}
+		later := copies[1]
+		r.add(Finding{
+			ID: "ssh_config.duplicate_alias", Severity: SeverityWarn, Category: CatSSHConfig,
+			Title: "Host \"" + alias + "\" is defined more than once",
+			Path:  e.display(later.Source), Line: later.Line, Host: alias,
+			Detail: "Bast lists the first copy only (" + e.display(copies[0].Source) + "). Later blocks still apply in OpenSSH for unset keywords and extra IdentityFile lines.",
+		})
+	}
+}
+
+func (e Engine) checkMatchAndWildcards(r *Report, ins sshconfig.Inspection) {
+	if len(ins.Matches) > 0 {
+		m := ins.Matches[0]
+		r.add(Finding{
+			ID: "ssh_config.match_blocks", Severity: SeverityInfo, Category: CatSSHConfig,
+			Title: "Match blocks are present", Path: e.display(m.Source), Line: m.Line,
+			Detail: "OpenSSH applies Match rules. Bast's host picker does not list them as hosts.",
+		})
+	}
+	var wild []sshconfig.InspectHost
+	for _, h := range ins.Hosts {
+		if h.Wildcard {
+			wild = append(wild, h)
+		}
+	}
+	if len(wild) > 0 {
+		h := wild[0]
+		r.add(Finding{
+			ID: "ssh_config.wildcard_hosts", Severity: SeverityInfo, Category: CatSSHConfig,
+			Title: "Wildcard Host patterns are present", Path: e.display(h.Source), Line: h.Line,
+			Detail: "Patterns like Host * still apply in OpenSSH. Bast only lists literal aliases in the picker.",
+		})
+	}
+}
+
+func (e Engine) checkHosts(r *Report, ins sshconfig.Inspection, st runState) {
+	literals := st.hosts
+	if literals == nil {
+		literals = e.literalHosts(ins)
+	}
+	known := map[string]bool{}
+	for _, h := range literals {
+		known[h.Alias] = true
+	}
+	tooMany := 0
+	for _, h := range literals {
+		e.checkOneHost(r, h, known, st, &tooMany)
+	}
+}
+
+func (e Engine) checkOneHost(r *Report, h effectiveHost, known map[string]bool, st runState, tooMany *int) {
+	if h.HostName == "" && !looksLikeHostname(h.Alias) {
+		r.add(Finding{
+			ID: "ssh_config.hostname_missing", Severity: SeverityWarn, Category: CatSSHConfig,
+			Title: "Host \"" + h.Alias + "\" has no HostName", Path: e.display(h.Source), Line: h.Line, Host: h.Alias,
+			Detail: "OpenSSH will use the alias as the DNS name.",
+			Fix:    "Set HostName, or edit the host in Bast.",
+		})
+	}
+	if len(h.IdentityFiles) > 0 {
+		for i, id := range h.IdentityFiles {
+			raw := id
+			if i < len(h.RawIdentityFiles) {
+				raw = h.RawIdentityFiles[i]
+			}
+			if strings.HasSuffix(raw, ".pub") || strings.HasSuffix(id, ".pub") {
+				r.add(Finding{
+					ID: "ssh_config.identity_is_public", Severity: SeverityFail, Category: CatSSHConfig,
+					Title: "IdentityFile for \"" + h.Alias + "\" points at a .pub file",
+					Path:  e.display(id), Host: h.Alias,
+					Detail: "IdentityFile must be the private key.",
+					Fix:    "Point IdentityFile at the private key (no .pub suffix).",
+				})
+			}
+			if !fileExists(id) {
+				r.add(Finding{
+					ID: "ssh_config.identity_missing", Severity: SeverityFail, Category: CatSSHConfig,
+					Title: "IdentityFile for \"" + h.Alias + "\" does not exist",
+					Path:  e.display(id), Host: h.Alias,
+					Detail: "OpenSSH will try a missing key and fail that method.",
+					Fix:    "Create the key, or point the host at an existing identity in Bast.",
+				})
+			}
+			if !filepath.IsAbs(raw) && !strings.HasPrefix(raw, "~") {
+				r.add(Finding{
+					ID: "ssh_config.identity_relative", Severity: SeverityWarn, Category: CatSSHConfig,
+					Title: "IdentityFile for \"" + h.Alias + "\" is a relative path",
+					Path:  raw, Host: h.Alias,
+					Detail: "Relative IdentityFile paths are resolved from the current working directory, not ~/.ssh.",
+				})
+			}
+		}
+	}
+	if h.CertificateFile != "" && len(h.IdentityFiles) == 0 {
+		r.add(Finding{
+			ID: "ssh_config.certificate_without_identity", Severity: SeverityWarn, Category: CatSSHConfig,
+			Title: "CertificateFile for \"" + h.Alias + "\" has no IdentityFile",
+			Path:  e.display(h.CertificateFile), Host: h.Alias,
+			Detail: "A certificate needs the matching private key.",
+		})
+	}
+	if hop := firstHop(h.ProxyJump); hop != "" && !known[hop] && !looksLikeHostname(hop) {
+		r.add(Finding{
+			ID: "ssh_config.proxyjump_unknown", Severity: SeverityWarn, Category: CatSSHConfig,
+			Title: "ProxyJump \"" + hop + "\" for \"" + h.Alias + "\" is not a known host",
+			Path:  e.display(h.Source), Line: h.Line, Host: h.Alias,
+			Detail: "OpenSSH must resolve that jump as an alias or a hostname.",
+		})
+	}
+	if yesValue(h.ForwardAgent) && !st.agent.present {
+		r.add(Finding{
+			ID: "ssh_config.forward_agent_no_agent", Severity: SeverityWarn, Category: CatSSHConfig,
+			Title: "ForwardAgent is yes on \"" + h.Alias + "\" but no agent is running",
+			Path:  e.display(h.Source), Line: h.Line, Host: h.Alias,
+		})
+	}
+	if h.ControlPath != "" && h.ControlMaster == "" {
+		r.add(Finding{
+			ID: "ssh_config.controlpath_without_master", Severity: SeverityInfo, Category: CatSSHConfig,
+			Title: "ControlPath is set on \"" + h.Alias + "\" without ControlMaster",
+			Path:  e.display(h.Source), Line: h.Line, Host: h.Alias,
+		})
+	}
+	offered := existingFiles(h.IdentityFiles)
+	if len(h.IdentityFiles) == 0 {
+		offered = existingFiles(defaultIdentityFiles(e.Paths.Home))
+	}
+	identitiesOnly := yesValue(h.IdentitiesOnly)
+	count := len(offered)
+	if !identitiesOnly && st.agent.present {
+		count += st.agent.count
+	}
+	if count >= 4 && *tooMany < 8 {
+		*tooMany++
+		sev := SeverityWarn
+		if count >= 6 {
+			sev = SeverityFail
+		}
+		r.add(Finding{
+			ID: "ssh_config.too_many_identities", Severity: sev, Category: CatSSHConfig,
+			Title: "Host \"" + h.Alias + "\" offers many identities",
+			Path:  e.display(h.Source), Line: h.Line, Host: h.Alias,
+			Detail: "OpenSSH may hit \"Too many authentication failures\" when it tries every agent key and IdentityFile.",
+			Fix:    "Set IdentitiesOnly yes on this host, or in Bast: edit the host and add that SSH flag.",
+		})
+	}
+}
+
+func (e Engine) includeIs(inc sshconfig.InspectInclude, target string) bool {
+	if target == "" {
+		return false
+	}
+	want := filepath.Clean(target)
+	if filepath.Clean(inc.Expanded) == want {
+		return true
+	}
+	for _, match := range inc.Matches {
+		if filepath.Clean(match) == want {
+			return true
+		}
+	}
+	rel := e.display(target)
+	if inc.Pattern == rel || inc.Pattern == target {
+		return true
+	}
+	if strings.Contains(inc.Pattern, "bast/config") && strings.HasSuffix(want, string(filepath.Separator)+"bast"+string(filepath.Separator)+"config") {
+		if !strings.Contains(inc.Pattern, "/sync/") && !strings.Contains(want, string(filepath.Separator)+"sync"+string(filepath.Separator)) {
+			return filepath.Base(want) == "config" && filepath.Base(filepath.Dir(want)) == "bast"
+		}
+	}
+	return false
+}

--- a/apps/bast/internal/doctor/check_env.go
+++ b/apps/bast/internal/doctor/check_env.go
@@ -1,0 +1,141 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func (e Engine) checkEnv(ctx context.Context, r *Report) {
+	type tool struct {
+		name string
+		bin  string
+	}
+	tools := []tool{
+		{"ssh", e.OpenSSH.SSH},
+		{"ssh-keygen", e.OpenSSH.SSHKeygen},
+		{"ssh-add", e.OpenSSH.SSHAdd},
+	}
+	var present []string
+	var missing []string
+	var resolved string
+	for _, t := range tools {
+		name := t.bin
+		if name == "" {
+			name = t.name
+		}
+		path, err := exec.LookPath(name)
+		if err != nil {
+			missing = append(missing, t.name)
+			continue
+		}
+		present = append(present, t.name)
+		if t.name == "ssh" {
+			resolved = path
+		}
+	}
+	if len(missing) > 0 {
+		detail := "Bast needs the system OpenSSH commands on PATH."
+		if runtime.GOOS == "windows" {
+			detail = "Install OpenSSH Client from Windows Optional Features."
+		}
+		r.add(Finding{
+			ID: "env.openssh_missing", Severity: SeverityFail, Category: CatEnv,
+			Title: "Missing " + strings.Join(missing, ", "), Detail: detail,
+			Fix: "Install OpenSSH and ensure ssh, ssh-keygen, and ssh-add are on PATH.",
+		})
+		return
+	}
+	version := e.sshVersion(ctx)
+	title := strings.Join(present, " · ")
+	if version != "" {
+		title = "ssh " + version + " · ssh-keygen · ssh-add"
+	}
+	r.add(Finding{ID: "env.openssh_ok", Severity: SeverityOK, Category: CatEnv, Title: title})
+	if runtime.GOOS == "windows" && gitSSH(resolved) {
+		r.add(Finding{
+			ID: "env.git_ssh", Severity: SeverityWarn, Category: CatEnv,
+			Title:  "PATH ssh is Git's copy, not Windows OpenSSH",
+			Path:   resolved,
+			Detail: "Git for Windows ships its own ssh.exe. Bast expects the Windows OpenSSH Client.",
+			Fix:    "Put Windows OpenSSH ahead of Git on PATH, or install OpenSSH Client from Optional Features.",
+		})
+	}
+}
+
+func (e Engine) sshVersion(ctx context.Context) string {
+	bin := e.OpenSSH.SSH
+	if bin == "" {
+		bin = "ssh"
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, "-V")
+	var stderr bytes.Buffer
+	cmd.Stdout = &stderr
+	cmd.Stderr = &stderr
+	_ = cmd.Run()
+	line := strings.TrimSpace(stderr.String())
+	if line == "" {
+		return ""
+	}
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	line = strings.TrimPrefix(line, "OpenSSH_")
+	if fields := strings.Fields(line); len(fields) > 0 {
+		return fields[0]
+	}
+	return line
+}
+
+func gitSSH(path string) bool {
+	norm := strings.ToLower(filepath.ToSlash(path))
+	return strings.Contains(norm, "/git/") && strings.Contains(norm, "/ssh")
+}
+
+func (e Engine) inspectAgent(ctx context.Context) agentState {
+	st := agentState{checked: true}
+	if runtime.GOOS != "windows" && os.Getenv("SSH_AUTH_SOCK") == "" {
+		st.err = "SSH_AUTH_SOCK is unset"
+		return st
+	}
+	bin := e.OpenSSH.SSHAdd
+	if bin == "" {
+		bin = "ssh-add"
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, "-l")
+	out, err := cmd.Output()
+	if err == nil {
+		st.present = true
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.TrimSpace(line) != "" {
+				st.count++
+			}
+		}
+		st.empty = st.count == 0
+		return st
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case 1:
+			st.present = true
+			st.empty = true
+			return st
+		case 2:
+			st.err = "cannot connect to the ssh-agent"
+			return st
+		}
+	}
+	st.err = err.Error()
+	return st
+}

--- a/apps/bast/internal/doctor/check_keys.go
+++ b/apps/bast/internal/doctor/check_keys.go
@@ -1,0 +1,122 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"bast/internal/keys"
+)
+
+func (e Engine) checkKeys(ctx context.Context, r *Report, st runState) {
+	for _, key := range st.keys {
+		if len(key.References) > 0 && key.PrivatePath != "" && !fileExists(key.PrivatePath) {
+			r.add(Finding{
+				ID: "keys.referenced_missing", Severity: SeverityFail, Category: CatKeys,
+				Title: "Referenced key \"" + key.Name + "\" is missing", Path: e.display(key.PrivatePath),
+				Detail: "Hosts " + strings.Join(key.References, ", ") + " point at this identity.",
+			})
+		}
+		if key.PrivatePath != "" && key.PublicPath == "" {
+			r.add(Finding{
+				ID: "keys.private_without_public", Severity: SeverityWarn, Category: CatKeys,
+				Title: "Key \"" + key.Name + "\" has no .pub file", Path: e.display(key.PrivatePath),
+			})
+		}
+		if key.PublicPath != "" && key.PrivatePath == "" && !key.InAgent {
+			r.add(Finding{
+				ID: "keys.public_without_private", Severity: SeverityWarn, Category: CatKeys,
+				Title: "Key \"" + key.Name + "\" has a public file only", Path: e.display(key.PublicPath),
+			})
+		}
+		if len(key.References) == 0 && key.Managed && key.PrivatePath != "" {
+			r.add(Finding{
+				ID: "keys.unreferenced", Severity: SeverityInfo, Category: CatKeys,
+				Title: "Key \"" + key.Name + "\" is not used by any host", Path: e.display(key.PrivatePath),
+			})
+		}
+		algo := strings.ToLower(key.Algorithm)
+		if algo == "dsa" || algo == "ssh-dss" {
+			r.add(Finding{
+				ID: "keys.dsa", Severity: SeverityWarn, Category: CatKeys,
+				Title: "Key \"" + key.Name + "\" uses DSA", Path: e.display(key.PrivatePath),
+				Detail: "OpenSSH has disabled DSA by default.",
+			})
+		}
+		if algo == "rsa" || algo == "ssh-rsa" {
+			if bits := e.keyBits(ctx, key); bits > 0 && bits < 2048 {
+				r.add(Finding{
+					ID: "keys.rsa_small", Severity: SeverityWarn, Category: CatKeys,
+					Title: "Key \"" + key.Name + "\" is RSA shorter than 2048 bits", Path: e.display(key.PrivatePath),
+				})
+			}
+		}
+		if key.PrivatePath != "" && !key.InAgent && e.keyEncrypted(ctx, key.PrivatePath) {
+			r.add(Finding{
+				ID: "keys.passphrase_not_in_agent", Severity: SeverityWarn, Category: CatKeys,
+				Title:  "Passphrase-protected key \"" + key.Name + "\" is not in the agent",
+				Path:   e.display(key.PrivatePath),
+				Detail: "Each connection will prompt for the passphrase.",
+				Fix:    "ssh-add " + e.display(key.PrivatePath),
+			})
+		}
+	}
+}
+
+func (e Engine) keyBits(ctx context.Context, key keys.Key) int {
+	inspect := key.PublicPath
+	if inspect == "" {
+		inspect = key.PrivatePath
+	}
+	if inspect == "" {
+		return 0
+	}
+	bin := e.OpenSSH.SSHKeygen
+	if bin == "" {
+		bin = "ssh-keygen"
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, "-lf", inspect)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func (e Engine) keyEncrypted(ctx context.Context, path string) bool {
+	if path == "" {
+		return false
+	}
+	if b, err := os.ReadFile(path); err == nil {
+		s := string(b)
+		if strings.Contains(s, "ENCRYPTED") || strings.Contains(s, "bcrypt") {
+			return true
+		}
+	}
+	bin := e.OpenSSH.SSHKeygen
+	if bin == "" {
+		bin = "ssh-keygen"
+	}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, "-y", "-P", "", "-f", path)
+	out, err := cmd.CombinedOutput()
+	if err == nil || cctx.Err() != nil {
+		return false
+	}
+	msg := strings.ToLower(string(out) + err.Error())
+	return strings.Contains(msg, "passphrase") || strings.Contains(msg, "decrypt")
+}

--- a/apps/bast/internal/doctor/check_knownhosts.go
+++ b/apps/bast/internal/doctor/check_knownhosts.go
@@ -1,0 +1,87 @@
+package doctor
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (e Engine) checkKnownHosts(ctx context.Context, r *Report, st runState) {
+	_ = ctx
+	path := filepath.Join(e.Paths.SSHDir, "known_hosts")
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	dupesByType := map[string]int{}
+	hostsSeen := map[string]int{}
+	hashed := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if strings.HasPrefix(fields[0], "@") {
+			if len(fields) < 3 {
+				continue
+			}
+			fields = fields[1:]
+		}
+		hostField, keyType := fields[0], fields[1]
+		if strings.HasPrefix(hostField, "|1|") {
+			hashed++
+			continue
+		}
+		for _, host := range strings.Split(hostField, ",") {
+			host = strings.TrimPrefix(host, "[")
+			host = strings.TrimSuffix(host, "]")
+			if i := strings.LastIndex(host, "]:"); i >= 0 {
+				host = strings.TrimPrefix(host[:i], "[")
+			}
+			hostsSeen[host]++
+			dupesByType[host+" "+keyType]++
+		}
+	}
+	dupes := 0
+	var sample string
+	for hostKey, n := range dupesByType {
+		if n > 1 {
+			dupes++
+			if sample == "" {
+				sample = hostKey
+			}
+		}
+	}
+	if dupes > 0 {
+		r.add(Finding{
+			ID: "known_hosts.duplicates", Severity: SeverityWarn, Category: CatKnownHosts,
+			Title: "known_hosts has duplicate host entries", Path: e.display(path),
+			Detail: "Example: " + sample + ". Remove stale lines with bast hosts known-host remove <host>.",
+		})
+	}
+	unseen := 0
+	for _, h := range st.hosts {
+		name := h.HostName
+		if name == "" {
+			name = h.Alias
+		}
+		if hostsSeen[name] == 0 && hashed == 0 {
+			unseen++
+		}
+	}
+	if unseen > 3 {
+		r.add(Finding{
+			ID: "known_hosts.unseen", Severity: SeverityInfo, Category: CatKnownHosts,
+			Title: "Several hosts have no known_hosts entry", Path: e.display(path),
+			Detail: "First connect will prompt to trust the host key.",
+		})
+	}
+}

--- a/apps/bast/internal/doctor/check_metadata.go
+++ b/apps/bast/internal/doctor/check_metadata.go
@@ -1,0 +1,66 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"bast/internal/metadata"
+)
+
+func (e Engine) checkMetadata(r *Report, st runState) {
+	if st.storeErr != nil {
+		r.add(Finding{
+			ID: "metadata.unreadable", Severity: SeverityFail, Category: CatMetadata,
+			Title: "state.json could not be read", Path: e.display(e.Paths.StateFile),
+			Detail: st.storeErr.Error(),
+		})
+		return
+	}
+	if st.store == nil {
+		return
+	}
+	if !fileExists(e.Paths.StateFile) {
+		return
+	}
+	hosts := st.store.Hosts()
+	known := map[string]bool{}
+	for _, h := range st.hosts {
+		known[h.Alias] = true
+	}
+	orphans := 0
+	for alias, meta := range hosts {
+		if !known[alias] && (meta.Label != "" || meta.Group != "" || meta.Notes != "" || meta.Favorite || meta.Hidden) {
+			orphans++
+		}
+		if meta.Group != "" {
+			if _, err := metadata.NormalizeGroupPath(meta.Group); err != nil {
+				r.add(Finding{
+					ID: "metadata.invalid_group", Severity: SeverityWarn, Category: CatMetadata,
+					Title: "Host \"" + alias + "\" has an invalid group path", Host: alias,
+					Detail: err.Error(),
+				})
+			}
+		}
+	}
+	if orphans > 0 {
+		r.add(Finding{
+			ID: "metadata.orphans", Severity: SeverityInfo, Category: CatMetadata,
+			Title:  "Metadata remains for hosts that are no longer in SSH config",
+			Path:   e.display(e.Paths.StateFile),
+			Detail: "Groups, notes, and favorites for deleted aliases stay in state.json.",
+		})
+	}
+	if runtime.GOOS == "darwin" {
+		if configDir, err := os.UserConfigDir(); err == nil {
+			legacy := filepath.Join(configDir, "bast", "state.json")
+			if fileExists(legacy) && filepath.Clean(legacy) != filepath.Clean(e.Paths.StateFile) {
+				r.add(Finding{
+					ID: "metadata.legacy_state", Severity: SeverityInfo, Category: CatMetadata,
+					Title: "Legacy state file is still present", Path: e.display(legacy),
+					Detail: "Bast now uses ~/.config/bast/state.json.",
+				})
+			}
+		}
+	}
+}

--- a/apps/bast/internal/doctor/check_perm.go
+++ b/apps/bast/internal/doctor/check_perm.go
@@ -1,0 +1,133 @@
+package doctor
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"bast/internal/platform"
+)
+
+func (e Engine) checkPerm(r *Report, st runState) {
+	if !platform.SupportsPOSIXPermissions() {
+		if dirExists(e.Paths.ManagedDir) {
+			r.add(Finding{
+				ID: "permissions.ok", Severity: SeverityOK, Category: CatPermissions,
+				Title: "Bast-managed paths are present (Windows DACL applied when Bast writes them)",
+			})
+		}
+		return
+	}
+	issues := 0
+	issues += e.checkDirWritable(r, e.Paths.SSHDir, "permissions.ssh_dir", "~/.ssh")
+	if fileExists(e.Paths.MainConfig) {
+		issues += e.checkOtherWritable(r, e.Paths.MainConfig, "permissions.ssh_config", "~/.ssh/config")
+	}
+	if dirExists(e.Paths.ManagedDir) {
+		issues += e.checkDirWritable(r, e.Paths.ManagedDir, "permissions.bast_dir", "~/.ssh/bast")
+	}
+	if dirExists(e.Paths.ManagedKeys) {
+		issues += e.checkDirWritable(r, e.Paths.ManagedKeys, "permissions.bast_keys_dir", "~/.ssh/bast/keys")
+	}
+	configDir := filepath.Dir(e.Paths.StateFile)
+	if dirExists(configDir) {
+		issues += e.checkDirWritable(r, configDir, "permissions.config_dir", "~/.config/bast")
+	}
+	for _, item := range []struct{ path, id, title string }{
+		{e.Paths.StateFile, "permissions.state", "~/.config/bast/state.json"},
+		{e.Paths.UpstashAPIKey, "permissions.upstash_key", "~/.config/bast/upstash-box-api-key"},
+	} {
+		if fileExists(item.path) {
+			issues += e.checkNotShared(r, item.path, item.id, item.title, 0o077)
+		}
+	}
+	issues += e.checkPrivateKeyModes(r, st)
+	if issues == 0 {
+		r.add(Finding{
+			ID: "permissions.ok", Severity: SeverityOK, Category: CatPermissions,
+			Title: "~/.ssh and identity files are not group or world accessible",
+		})
+	}
+}
+
+func (e Engine) checkDirWritable(r *Report, path, id, title string) int {
+	return e.checkNotShared(r, path, id, title, 0o022)
+}
+
+func (e Engine) checkOtherWritable(r *Report, path, id, title string) int {
+	return e.checkNotShared(r, path, id, title, 0o002)
+}
+
+func (e Engine) checkNotShared(r *Report, path, id, title string, bad fs.FileMode) int {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	mode := info.Mode().Perm()
+	if mode&bad == 0 {
+		return 0
+	}
+	fixMode := "600"
+	if info.IsDir() {
+		fixMode = "700"
+	}
+	detail := "OpenSSH refuses paths that are accessible by others."
+	if id == "permissions.ssh_config" {
+		detail = "OpenSSH warns when ~/.ssh/config is world-accessible."
+	}
+	r.add(Finding{
+		ID: id, Severity: SeverityFail, Category: CatPermissions,
+		Title: title + " mode is too open", Path: e.display(path),
+		Detail: detail, Fix: "chmod " + fixMode + " " + e.display(path), Fixable: true,
+	})
+	return 1
+}
+
+func (e Engine) checkPrivateKeyModes(r *Report, st runState) int {
+	issues := 0
+	seen := map[string]bool{}
+	scan := func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || strings.HasSuffix(entry.Name(), ".pub") {
+				continue
+			}
+			path := filepath.Join(dir, entry.Name())
+			if seen[path] || !looksPrivateKey(path) {
+				continue
+			}
+			seen[path] = true
+			issues += e.checkNotShared(r, path, "permissions.private_key", e.display(path), 0o077)
+		}
+	}
+	scan(e.Paths.SSHDir)
+	scan(e.Paths.ManagedKeys)
+	for _, h := range st.hosts {
+		for _, id := range h.IdentityFiles {
+			if id == "" || seen[id] || strings.HasSuffix(id, ".pub") || !fileExists(id) {
+				continue
+			}
+			if !looksPrivateKey(id) {
+				continue
+			}
+			seen[id] = true
+			issues += e.checkNotShared(r, id, "permissions.private_key", e.display(id), 0o077)
+		}
+	}
+	return issues
+}
+
+func looksPrivateKey(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	buf := make([]byte, 80)
+	n, _ := f.Read(buf)
+	return n > 0 && strings.Contains(string(buf[:n]), "PRIVATE KEY")
+}

--- a/apps/bast/internal/doctor/check_probe.go
+++ b/apps/bast/internal/doctor/check_probe.go
@@ -1,0 +1,62 @@
+package doctor
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+)
+
+func (e Engine) checkProbe(ctx context.Context, r *Report, st runState) {
+	literals := st.hosts
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 6*time.Second)
+		defer cancel()
+		deadline, _ = ctx.Deadline()
+	}
+	probed := 0
+	for _, h := range literals {
+		if probed >= 20 || time.Until(deadline) < 200*time.Millisecond {
+			break
+		}
+		host := h.HostName
+		if host == "" {
+			host = h.Alias
+		}
+		if host == "" {
+			continue
+		}
+		port := h.Port
+		if port == "" {
+			port = "22"
+		}
+		if _, err := strconv.Atoi(port); err != nil {
+			continue
+		}
+		probed++
+		pctx, cancel := context.WithTimeout(ctx, 400*time.Millisecond)
+		addrs, err := net.DefaultResolver.LookupHost(pctx, host)
+		if err != nil {
+			cancel()
+			r.add(Finding{
+				ID: "probe.dns", Severity: SeverityWarn, Category: CatProbe,
+				Title: "HostName \"" + host + "\" did not resolve", Host: h.Alias, Detail: err.Error(),
+			})
+			continue
+		}
+		_ = addrs
+		var d net.Dialer
+		conn, err := d.DialContext(pctx, "tcp", net.JoinHostPort(host, port))
+		cancel()
+		if err != nil {
+			r.add(Finding{
+				ID: "probe.tcp", Severity: SeverityWarn, Category: CatProbe,
+				Title: "Cannot connect to " + net.JoinHostPort(host, port), Host: h.Alias, Detail: err.Error(),
+			})
+			continue
+		}
+		_ = conn.Close()
+	}
+}

--- a/apps/bast/internal/doctor/check_suggest.go
+++ b/apps/bast/internal/doctor/check_suggest.go
@@ -1,0 +1,108 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+
+	"bast/internal/updater"
+)
+
+func (e Engine) checkSuggest(ctx context.Context, r *Report, st runState, opt Options) {
+	literals := st.hosts
+	var noIdentitiesOnly, noKeepalive, ungrouped, external int
+	useKeychain := false
+	addKeys := false
+	for _, h := range st.ins.Hosts {
+		if yesValue(h.UseKeychain) {
+			useKeychain = true
+		}
+		if yesValue(h.AddKeysToAgent) {
+			addKeys = true
+		}
+	}
+	for _, h := range literals {
+		if len(h.IdentityFiles) > 0 && !yesValue(h.IdentitiesOnly) {
+			noIdentitiesOnly++
+		}
+		if h.ServerAliveInterval == "" && h.HostName != "" && h.HostName != "localhost" && h.HostName != "127.0.0.1" {
+			noKeepalive++
+		}
+		if !h.Managed && !h.Synced {
+			external++
+		}
+	}
+	if st.store != nil {
+		for _, h := range literals {
+			if strings.TrimSpace(st.store.Host(h.Alias).Group) == "" && !h.Synced {
+				ungrouped++
+			}
+		}
+	}
+	if noIdentitiesOnly > 0 {
+		r.add(Finding{
+			ID: "suggest.identities_only", Severity: SeverityInfo, Category: CatSuggest,
+			Title:  "Hosts with IdentityFile do not set IdentitiesOnly",
+			Detail: "IdentitiesOnly yes stops ssh-agent from offering extra keys that cause \"Too many authentication failures\".",
+			Fix:    "Edit the host in Bast and add IdentitiesOnly yes, or set it on Host *.",
+		})
+	}
+	if noKeepalive > 2 {
+		r.add(Finding{
+			ID: "suggest.keepalive", Severity: SeverityInfo, Category: CatSuggest,
+			Title:  "No ServerAliveInterval on remote hosts",
+			Detail: "A 30-second keepalive drops idle NAT mappings less often.",
+			Fix:    "Add ServerAliveInterval 30 to Host * or to individual hosts.",
+		})
+	}
+	if runtime.GOOS == "darwin" && (!useKeychain || !addKeys) {
+		r.add(Finding{
+			ID: "suggest.macos_keychain", Severity: SeverityInfo, Category: CatSuggest,
+			Title:  "macOS keychain is not referenced in SSH config",
+			Detail: "UseKeychain yes and AddKeysToAgent yes store passphrases in the login keychain.",
+			Fix:    "Add UseKeychain yes and AddKeysToAgent yes under Host * in ~/.ssh/config.",
+		})
+	}
+	if ungrouped > 8 {
+		r.add(Finding{
+			ID: "suggest.groups", Severity: SeverityInfo, Category: CatSuggest,
+			Title:  "Many hosts have no group",
+			Detail: "Groups keep the picker scannable. Move hosts with m in the TUI, or bast hosts edit --group.",
+		})
+	}
+	if external > 0 {
+		r.add(Finding{
+			ID: "suggest.promote", Severity: SeverityInfo, Category: CatSuggest,
+			Title:  "External hosts can be promoted into Bast-managed config",
+			Detail: "Promotion copies the host into ~/.ssh/bast/config so Bast can edit connection settings. Press p in the TUI.",
+		})
+	}
+	e.checkUpdate(ctx, r, opt)
+}
+
+func (e Engine) checkUpdate(ctx context.Context, r *Report, opt Options) {
+	if e.Version == "" || e.Version == "dev" {
+		return
+	}
+	client := updaterClient(opt)
+	var latest string
+	var err error
+	switch {
+	case updater.IsStable(e.Version):
+		latest, err = updater.Check(ctx, client, e.Version)
+	case updater.IsNightly(e.Version):
+		latest, err = updater.CheckNightly(ctx, client, e.Version)
+	default:
+		return
+	}
+	if err != nil || latest == "" {
+		return
+	}
+	exe, _ := os.Executable()
+	r.add(Finding{
+		ID: "suggest.update", Severity: SeverityInfo, Category: CatSuggest,
+		Title: "A newer Bast is available (" + latest + ")",
+		Fix:   updater.Suggestion(exe),
+	})
+}

--- a/apps/bast/internal/doctor/check_sync.go
+++ b/apps/bast/internal/doctor/check_sync.go
@@ -1,0 +1,87 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	boxcloud "bast/internal/cloud/box"
+)
+
+func (e Engine) checkSync(r *Report, st runState) {
+	if st.store == nil {
+		return
+	}
+	type provider struct {
+		name    string
+		enabled bool
+		cli     string
+		err     string
+	}
+	providers := []provider{
+		{"gcp", st.store.GCP().Enabled, "gcloud", st.store.GCP().LastSyncError},
+		{"aws", st.store.AWS().Enabled, "aws", st.store.AWS().LastSyncError},
+		{"azure", st.store.Azure().Enabled, "az", st.store.Azure().LastSyncError},
+		{"box", st.store.Box().Enabled, "box", st.store.Box().LastSyncError},
+	}
+	for _, p := range providers {
+		if !p.enabled {
+			continue
+		}
+		if !providerCLIPresent(p.name, p.cli) {
+			title := p.name + " sync is enabled but " + p.cli + " is not on PATH"
+			fix := "Install the " + p.cli + " CLI, or run bast sync disable " + p.name + "."
+			detail := ""
+			if p.name == "box" {
+				title = "box sync is enabled but the Box CLI was not found"
+				detail = "The ASCII Box installer puts the binary at ~/.ascii/bin/box and a shell function named box. That function is not on PATH, so Bast looks at ~/.ascii/bin/box, ~/.local/bin/box, and BOX_CLI."
+				fix = "Install from https://box.ascii.dev/, set BOX_CLI to the binary, or run bast sync disable box."
+			}
+			r.add(Finding{
+				ID: "sync.cli_missing", Severity: SeverityFail, Category: CatSync,
+				Title: title, Detail: detail, Fix: fix,
+			})
+		}
+		if strings.TrimSpace(p.err) != "" {
+			r.add(Finding{
+				ID: "sync.last_error", Severity: SeverityWarn, Category: CatSync,
+				Title: p.name + " last sync failed", Detail: p.err,
+			})
+		}
+	}
+	up := st.store.Upstash()
+	if up.Enabled && !fileExists(e.Paths.UpstashAPIKey) && os.Getenv("UPSTASH_BOX_API_KEY") == "" {
+		r.add(Finding{
+			ID: "sync.upstash_key_missing", Severity: SeverityFail, Category: CatSync,
+			Title: "Upstash sync is enabled but no API key is stored",
+			Path:  e.display(e.Paths.UpstashAPIKey),
+			Fix:   "bast upstash key --key-file <path>",
+		})
+	}
+	if up.Enabled && strings.TrimSpace(up.LastSyncError) != "" {
+		r.add(Finding{
+			ID: "sync.last_error", Severity: SeverityWarn, Category: CatSync,
+			Title: "upstash last sync failed", Detail: up.LastSyncError,
+		})
+	}
+}
+
+func providerCLIPresent(name, cli string) bool {
+	if name == "box" {
+		return boxCLIPresent()
+	}
+	_, err := exec.LookPath(cli)
+	return err == nil
+}
+
+func boxCLIPresent() bool {
+	bin := boxcloud.New().Box
+	if bin == "" {
+		return false
+	}
+	if _, err := exec.LookPath(bin); err == nil {
+		return true
+	}
+	info, err := os.Stat(bin)
+	return err == nil && !info.IsDir()
+}

--- a/apps/bast/internal/doctor/check_vault.go
+++ b/apps/bast/internal/doctor/check_vault.go
@@ -1,0 +1,43 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+
+	"bast/internal/platform"
+	"bast/internal/vault"
+)
+
+func platformPOSIX() bool { return platform.SupportsPOSIXPermissions() }
+
+func (e Engine) checkVault(r *Report) {
+	sessionPath := vault.SessionPath(e.Paths.StateFile)
+	passPath := vault.PassphrasePath(e.Paths.StateFile)
+	if fileExists(sessionPath) {
+		b, err := os.ReadFile(sessionPath)
+		if err != nil {
+			r.add(Finding{
+				ID: "vault.session_unreadable", Severity: SeverityWarn, Category: CatVault,
+				Title: "Vault session file could not be read", Path: e.display(sessionPath),
+				Detail: err.Error(),
+			})
+		} else if !json.Valid(b) {
+			r.add(Finding{
+				ID: "vault.session_unreadable", Severity: SeverityWarn, Category: CatVault,
+				Title: "Vault session file is not valid JSON", Path: e.display(sessionPath),
+			})
+		}
+	}
+	if fileExists(passPath) && platformPOSIX() {
+		info, err := os.Stat(passPath)
+		if err == nil && info.Mode().Perm()&0o077 != 0 {
+			r.add(Finding{
+				ID: "vault.passphrase_mode", Severity: SeverityFail, Category: CatVault,
+				Title: "Vault passphrase file mode is too open", Path: e.display(passPath),
+				Detail:  "Anyone who can read this file can decrypt the vault.",
+				Fix:     "chmod 600 " + e.display(passPath),
+				Fixable: true,
+			})
+		}
+	}
+}

--- a/apps/bast/internal/doctor/doctor.go
+++ b/apps/bast/internal/doctor/doctor.go
@@ -1,0 +1,311 @@
+package doctor
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"bast/internal/keys"
+	"bast/internal/metadata"
+	"bast/internal/openssh"
+	"bast/internal/paths"
+	"bast/internal/platform"
+	"bast/internal/sshconfig"
+)
+
+type Options struct {
+	Fix        bool
+	Probe      bool
+	Categories []string
+	HTTP       *http.Client
+}
+
+type Engine struct {
+	Paths   paths.Paths
+	OpenSSH openssh.Client
+	Config  sshconfig.Manager
+	Keyring keys.Manager
+	Version string
+}
+
+type runState struct {
+	ins      sshconfig.Inspection
+	hosts    []effectiveHost
+	store    *metadata.Store
+	storeErr error
+	keys     []keys.Key
+	agent    agentState
+}
+
+type agentState struct {
+	checked bool
+	present bool
+	empty   bool
+	count   int
+	err     string
+}
+
+type effectiveHost struct {
+	Alias               string
+	Source              string
+	Line                int
+	HostName            string
+	User                string
+	Port                string
+	IdentityFiles       []string
+	RawIdentityFiles    []string
+	IdentitiesOnly      string
+	ProxyJump           string
+	ForwardAgent        string
+	CertificateFile     string
+	ServerAliveInterval string
+	ControlPath         string
+	ControlMaster       string
+	UseKeychain         string
+	AddKeysToAgent      string
+	Managed             bool
+	Synced              bool
+	Literal             sshconfig.InspectHost
+}
+
+func New(p paths.Paths, client openssh.Client, version string) Engine {
+	return Engine{
+		Paths:   p,
+		OpenSSH: client,
+		Config: sshconfig.Manager{
+			Home: p.Home, MainConfig: p.MainConfig, ManagedDir: p.ManagedDir,
+			ManagedConfig: p.ManagedConfig, ManagedKeys: p.ManagedKeys,
+			SyncGCPConfig: p.SyncGCPConfig, SyncAWSConfig: p.SyncAWSConfig,
+			SyncAzureConfig: p.SyncAzureConfig, SyncBoxConfig: p.SyncBoxConfig,
+			SyncUpstashConfig: p.SyncUpstashConfig,
+		},
+		Keyring: keys.Manager{Paths: p, SSHKeygen: client.SSHKeygen, SSHAdd: client.SSHAdd},
+		Version: version,
+	}
+}
+
+func (e Engine) Run(ctx context.Context, opt Options) Report {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	st := e.collect(ctx)
+	r := e.diagnose(ctx, opt, st)
+	if opt.Fix {
+		fixed := e.applyFixes(r)
+		st = e.collect(ctx)
+		r = e.diagnose(ctx, Options{Probe: opt.Probe, Categories: opt.Categories, HTTP: opt.HTTP}, st)
+		r.Fixed = fixed
+		r.finalize()
+	}
+	return r
+}
+
+func (e Engine) collect(ctx context.Context) runState {
+	st := runState{ins: e.Config.Inspect()}
+	st.hosts = e.literalHosts(st.ins)
+	st.store, st.storeErr = metadata.Open(e.Paths.StateFile)
+	referenced := map[string][]string{}
+	for _, h := range st.hosts {
+		for _, id := range h.IdentityFiles {
+			referenced[id] = append(referenced[id], h.Alias)
+		}
+	}
+	keyCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+	if list, err := e.Keyring.Discover(keyCtx, referenced); err == nil {
+		st.keys = list
+	}
+	st.agent = e.inspectAgent(ctx)
+	return st
+}
+
+func (e Engine) diagnose(ctx context.Context, opt Options, st runState) Report {
+	var r Report
+	e.checkEnv(ctx, &r)
+	e.checkPerm(&r, st)
+	e.checkConfig(&r, st)
+	e.checkKeys(ctx, &r, st)
+	e.checkAgent(&r, st)
+	e.checkKnownHosts(ctx, &r, st)
+	e.checkMetadata(&r, st)
+	e.checkVault(&r)
+	e.checkSync(&r, st)
+	e.checkSuggest(ctx, &r, st, opt)
+	if opt.Probe {
+		e.checkProbe(ctx, &r, st)
+	}
+	r.filter(opt.Categories)
+	r.finalize()
+	return r
+}
+
+func (e Engine) display(path string) string {
+	if path == "" {
+		return path
+	}
+	return platform.HomeRelative(path, e.Paths.Home)
+}
+
+func (e Engine) literalHosts(ins sshconfig.Inspection) []effectiveHost {
+	seen := map[string]bool{}
+	var out []effectiveHost
+	for _, h := range ins.Hosts {
+		if h.Wildcard || !selectable(h.Alias) {
+			continue
+		}
+		if seen[h.Alias] {
+			continue
+		}
+		seen[h.Alias] = true
+		out = append(out, e.effective(ins, h))
+	}
+	return out
+}
+
+func selectable(alias string) bool {
+	return alias != "" && !strings.HasPrefix(alias, "!") && !strings.ContainsAny(alias, `*?%#\"' `+"\t\r\n\x00")
+}
+
+func (e Engine) effective(ins sshconfig.Inspection, first sshconfig.InspectHost) effectiveHost {
+	out := effectiveHost{
+		Alias:   first.Alias,
+		Source:  first.Source,
+		Line:    first.Line,
+		Managed: first.Managed,
+		Synced:  first.Synced,
+		Literal: first,
+	}
+	for _, block := range ins.Hosts {
+		if !sshconfig.HostPatternMatch(block.Alias, first.Alias) {
+			continue
+		}
+		if out.HostName == "" {
+			out.HostName = block.HostName
+		}
+		if out.User == "" {
+			out.User = block.User
+		}
+		if out.Port == "" {
+			out.Port = block.Port
+		}
+		out.IdentityFiles = append(out.IdentityFiles, block.IdentityFiles...)
+		out.RawIdentityFiles = append(out.RawIdentityFiles, block.RawIdentityFiles...)
+		if out.IdentitiesOnly == "" {
+			out.IdentitiesOnly = block.IdentitiesOnly
+		}
+		if out.ProxyJump == "" {
+			out.ProxyJump = block.ProxyJump
+		}
+		if out.ForwardAgent == "" {
+			out.ForwardAgent = block.ForwardAgent
+		}
+		if out.CertificateFile == "" {
+			out.CertificateFile = block.CertificateFile
+		}
+		if out.ServerAliveInterval == "" {
+			out.ServerAliveInterval = block.ServerAliveInterval
+		}
+		if out.ControlPath == "" {
+			out.ControlPath = block.ControlPath
+		}
+		if out.ControlMaster == "" {
+			out.ControlMaster = block.ControlMaster
+		}
+		if out.UseKeychain == "" {
+			out.UseKeychain = block.UseKeychain
+		}
+		if out.AddKeysToAgent == "" {
+			out.AddKeysToAgent = block.AddKeysToAgent
+		}
+	}
+	return out
+}
+
+func existingFiles(paths []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		info, err := os.Stat(p)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}
+
+func defaultIdentityFiles(home string) []string {
+	dir := filepath.Join(home, ".ssh")
+	names := []string{"id_rsa", "id_ecdsa", "id_ecdsa_sk", "id_ed25519", "id_ed25519_sk", "id_xmss", "id_dsa"}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, filepath.Join(dir, name))
+	}
+	return out
+}
+
+func yesValue(value string) bool {
+	v := strings.ToLower(strings.TrimSpace(value))
+	return v == "yes" || v == "true"
+}
+
+func firstHop(proxy string) string {
+	proxy = strings.TrimSpace(proxy)
+	if proxy == "" || strings.EqualFold(proxy, "none") {
+		return ""
+	}
+	first, _, _ := strings.Cut(proxy, ",")
+	first = strings.TrimSpace(first)
+	if i := strings.LastIndex(first, "@"); i >= 0 {
+		first = first[i+1:]
+	}
+	if strings.HasPrefix(first, "[") {
+		if end := strings.Index(first, "]"); end > 0 {
+			return first[1:end]
+		}
+	}
+	if host, _, ok := strings.Cut(first, ":"); ok && !strings.Contains(first, "::") {
+		return host
+	}
+	return first
+}
+
+func looksLikeHostname(value string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.Contains(value, ".") || strings.Contains(value, ":") {
+		return true
+	}
+	if strings.EqualFold(value, "localhost") {
+		return true
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func updaterClient(opt Options) *http.Client {
+	if opt.HTTP != nil {
+		return opt.HTTP
+	}
+	return &http.Client{Timeout: 2 * time.Second}
+}

--- a/apps/bast/internal/doctor/doctor_test.go
+++ b/apps/bast/internal/doctor/doctor_test.go
@@ -1,0 +1,275 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"bast/internal/metadata"
+	"bast/internal/openssh"
+	"bast/internal/paths"
+)
+
+func testEngine(t *testing.T) (Engine, paths.Paths) {
+	t.Helper()
+	home := t.TempDir()
+	p := paths.ForHome(home)
+	if err := os.MkdirAll(p.SSHDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	return New(p, openssh.Default(), "dev"), p
+}
+
+func write(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func findingIDs(r Report) []string {
+	var out []string
+	for _, f := range r.Findings {
+		out = append(out, f.ID)
+	}
+	return out
+}
+
+func hasID(r Report, id string) bool {
+	for _, f := range r.Findings {
+		if f.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func finding(r Report, id string) Finding {
+	for _, f := range r.Findings {
+		if f.ID == id {
+			return f
+		}
+	}
+	return Finding{}
+}
+
+func TestIncludeInsideHostBlock(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.ManagedConfig, "Host managed\n  HostName managed.example\n", 0600)
+	write(t, p.MainConfig, "Host work\n  HostName work.example\n  Include ~/.ssh/bast/config\n", 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "ssh_config.include_not_toplevel") {
+		t.Fatalf("expected include_not_toplevel, got %v", findingIDs(r))
+	}
+	f := finding(r, "ssh_config.include_not_toplevel")
+	if f.Severity != SeverityFail || !f.Fixable {
+		t.Fatalf("finding = %+v", f)
+	}
+	if r.Healthy {
+		t.Fatal("expected unhealthy report")
+	}
+}
+
+func TestRelativeIdentityFile(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "Host api\n  HostName api.example\n  IdentityFile id_rel\n", 0600)
+	r := e.Run(context.Background(), Options{Categories: []string{"ssh_config"}})
+	if !hasID(r, "ssh_config.identity_relative") {
+		t.Fatalf("expected identity_relative, got %v", findingIDs(r))
+	}
+}
+
+func TestMissingIdentityFile(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "Host api\n  HostName api.example\n  IdentityFile ~/.ssh/missing_key\n", 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "ssh_config.identity_missing") {
+		t.Fatalf("expected identity_missing, got %v", findingIDs(r))
+	}
+	if finding(r, "ssh_config.identity_missing").Severity != SeverityFail {
+		t.Fatal("identity_missing should be fail")
+	}
+}
+
+func TestTooOpenPrivateKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX modes")
+	}
+	e, p := testEngine(t)
+	key := filepath.Join(p.SSHDir, "id_test")
+	write(t, key, "-----BEGIN OPENSSH PRIVATE KEY-----\ndata\n-----END OPENSSH PRIVATE KEY-----\n", 0644)
+	write(t, p.MainConfig, "Host api\n  HostName api.example\n  IdentityFile ~/.ssh/id_test\n", 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "permissions.private_key") {
+		t.Fatalf("expected private_key permission fail, got %v", findingIDs(r))
+	}
+}
+
+func TestDuplicateAliases(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "Host prod\n  HostName first.example\nHost prod\n  HostName second.example\n", 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "ssh_config.duplicate_alias") {
+		t.Fatalf("expected duplicate_alias, got %v", findingIDs(r))
+	}
+	f := finding(r, "ssh_config.duplicate_alias")
+	if f.Host != "prod" || f.Severity != SeverityWarn {
+		t.Fatalf("finding = %+v", f)
+	}
+}
+
+func TestCyclicIncludeStillReportsLaterHosts(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "Include loop.conf\nHost after\n  HostName after.example\n", 0600)
+	write(t, filepath.Join(p.SSHDir, "loop.conf"), "Include config\n", 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "ssh_config.include_cycle") {
+		t.Fatalf("expected include_cycle, got %v", findingIDs(r))
+	}
+}
+
+func TestTooManyIdentitiesFromHostStar(t *testing.T) {
+	e, p := testEngine(t)
+	var b strings.Builder
+	b.WriteString("Host *\n")
+	for i := 0; i < 6; i++ {
+		name := filepath.Join(p.SSHDir, "k"+string(rune('a'+i)))
+		write(t, name, "-----BEGIN OPENSSH PRIVATE KEY-----\nx\n-----END OPENSSH PRIVATE KEY-----\n", 0600)
+		b.WriteString("  IdentityFile ~/.ssh/k" + string(rune('a'+i)) + "\n")
+	}
+	b.WriteString("Host api\n  HostName api.example\n")
+	write(t, p.MainConfig, b.String(), 0600)
+	r := e.Run(context.Background(), Options{})
+	if !hasID(r, "ssh_config.too_many_identities") {
+		t.Fatalf("expected too_many_identities, got %v", findingIDs(r))
+	}
+}
+
+func TestFixPrependsInclude(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.ManagedConfig, "Host managed\n  HostName managed.example\n", 0600)
+	write(t, p.MainConfig, "Host work\n  HostName work.example\n  Include ~/.ssh/bast/config\n", 0600)
+	r := e.Run(context.Background(), Options{Fix: true})
+	if len(r.Fixed) == 0 {
+		t.Fatalf("expected a repair, findings=%v", findingIDs(r))
+	}
+	main, err := os.ReadFile(p.MainConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(main)
+	if !strings.Contains(text, "Include ~/.ssh/bast/config") {
+		t.Fatalf("include not present:\n%s", text)
+	}
+	if !strings.Contains(text, "# Added by Bast\nInclude ~/.ssh/bast/config") {
+		t.Fatalf("top-level include missing:\n%s", text)
+	}
+	if !strings.Contains(text, "Host work") {
+		t.Fatalf("user host was lost:\n%s", text)
+	}
+}
+
+func TestCategoryFilter(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "Host api\n  HostName api.example\n  IdentityFile ~/.ssh/missing_key\n", 0600)
+	r := e.Run(context.Background(), Options{Categories: []string{"ssh_config"}})
+	for _, f := range r.Findings {
+		if f.Category != CatSSHConfig {
+			t.Fatalf("unexpected category %s", f.Category)
+		}
+	}
+	if !hasID(r, "ssh_config.identity_missing") {
+		t.Fatalf("filter dropped identity_missing: %v", findingIDs(r))
+	}
+}
+
+func TestBoxCLIFoundAtAsciiInstallWithoutPATH(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX Box CLI fixture")
+	}
+	e, p := testEngine(t)
+	store, err := metadata.Open(p.StateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetBox(metadata.BoxIntegration{Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	boxBin := filepath.Join(p.Home, ".ascii", "bin", "box")
+	write(t, boxBin, "#!/bin/sh\n", 0755)
+	t.Setenv("HOME", p.Home)
+	t.Setenv("BOX_CLI", "")
+	t.Setenv("PATH", "/nonexistent")
+	r := e.Run(context.Background(), Options{Categories: []string{"sync"}})
+	if hasID(r, "sync.cli_missing") {
+		t.Fatalf("Box CLI at ~/.ascii/bin/box should be found without PATH: %v", findingIDs(r))
+	}
+}
+
+func TestBoxCLIMissingWhenEnabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX HOME/PATH isolation")
+	}
+	e, p := testEngine(t)
+	store, err := metadata.Open(p.StateFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetBox(metadata.BoxIntegration{Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", p.Home)
+	t.Setenv("BOX_CLI", "")
+	t.Setenv("PATH", "/nonexistent")
+	r := e.Run(context.Background(), Options{Categories: []string{"sync"}})
+	if !hasID(r, "sync.cli_missing") {
+		t.Fatalf("expected box CLI missing, got %v", findingIDs(r))
+	}
+}
+
+func TestFormatUsesTUIPaletteAndPlainPipes(t *testing.T) {
+	r := Report{Findings: []Finding{
+		{ID: "env.openssh_ok", Severity: SeverityOK, Category: CatEnv, Title: "ssh ok"},
+		{ID: "ssh_config.include_not_toplevel", Severity: SeverityFail, Category: CatSSHConfig, Title: "Include is inside a Host block", Path: "/tmp/config", Line: 12, Detail: "Move the Include to the top.", Fix: "Move Include to the top.", Fixable: true},
+	}}
+	r.finalize()
+	styled := render(r, 80)
+	if !strings.Contains(styled, "38;2;139;92;246") {
+		t.Fatalf("header/category should use TUI purple #8B5CF6:\n%q", styled)
+	}
+	if !strings.Contains(styled, "38;2;239;68;68") {
+		t.Fatalf("fail should use TUI red #EF4444:\n%q", styled)
+	}
+	if !strings.Contains(styled, "38;2;16;185;129") {
+		t.Fatalf("ok should use TUI green #10B981:\n%q", styled)
+	}
+	var buf strings.Builder
+	if err := Format(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	plain := buf.String()
+	if strings.Contains(plain, "\x1b") {
+		t.Fatalf("piped output should strip ANSI:\n%q", plain)
+	}
+	for _, want := range []string{"BAST", "doctor", "OpenSSH", "SSH config", "fail", "ok", "Include is inside a Host block", "/tmp/config:12", "Fix: Move Include to the top."} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("missing %q\n%s", want, plain)
+		}
+	}
+}
+
+func TestTopLevelIncludeIsNotReportedAsScoped(t *testing.T) {
+	e, p := testEngine(t)
+	write(t, p.MainConfig, "# Added by Bast\nInclude ~/.ssh/bast/config\n\nHost api\n  HostName api.example\n", 0600)
+	write(t, p.ManagedConfig, "", 0600)
+	r := e.Run(context.Background(), Options{Categories: []string{"ssh_config"}})
+	if hasID(r, "ssh_config.include_not_toplevel") {
+		t.Fatalf("false positive scoped include: %v", findingIDs(r))
+	}
+}

--- a/apps/bast/internal/doctor/fix.go
+++ b/apps/bast/internal/doctor/fix.go
@@ -1,0 +1,127 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"bast/internal/platform"
+)
+
+func (e Engine) applyFixes(r Report) []string {
+	var applied []string
+	needInclude := false
+	for _, f := range r.Findings {
+		if !f.Fixable {
+			continue
+		}
+		switch f.ID {
+		case "ssh_config.include_missing", "ssh_config.include_not_toplevel", "ssh_config.missing":
+			needInclude = true
+		case "permissions.ssh_dir", "permissions.bast_dir", "permissions.bast_keys_dir", "permissions.config_dir":
+			if e.fixDirMode(f.Path) {
+				applied = append(applied, "permissions on "+f.Path)
+			}
+		case "permissions.ssh_config", "permissions.state", "permissions.upstash_key", "permissions.private_key", "vault.passphrase_mode":
+			if e.fixFileMode(f.Path) {
+				applied = append(applied, "permissions on "+f.Path)
+			}
+		}
+	}
+	if needInclude {
+		if err := e.Config.EnsureManaged(); err == nil {
+			applied = append(applied, "Include ~/.ssh/bast/config at the top of ~/.ssh/config")
+		}
+	}
+	if platform.SupportsPOSIXPermissions() {
+		return uniqueStrings(applied)
+	}
+	for _, path := range []string{e.Paths.ManagedDir, e.Paths.ManagedKeys, e.Paths.ManagedConfig} {
+		if path == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			_ = platform.SecurePath(path, 0o700)
+		}
+	}
+	return uniqueStrings(applied)
+}
+
+func (e Engine) fixDirMode(displayPath string) bool {
+	path := e.expandDisplay(displayPath)
+	if path == "" {
+		return false
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		return false
+	}
+	return true
+}
+
+func (e Engine) fixFileMode(displayPath string) bool {
+	path := e.expandDisplay(displayPath)
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return e.fixDirMode(displayPath)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return false
+	}
+	return true
+}
+
+func (e Engine) expandDisplay(path string) string {
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	if path == "~/.ssh" {
+		return e.Paths.SSHDir
+	}
+	if path == "~/.ssh/config" {
+		return e.Paths.MainConfig
+	}
+	if path == "~/.ssh/bast" {
+		return e.Paths.ManagedDir
+	}
+	if path == "~/.ssh/bast/keys" {
+		return e.Paths.ManagedKeys
+	}
+	if path == "~/.config/bast" {
+		return filepath.Dir(e.Paths.StateFile)
+	}
+	if path == "~/.config/bast/state.json" {
+		return e.Paths.StateFile
+	}
+	if path == "~/.config/bast/upstash-box-api-key" {
+		return e.Paths.UpstashAPIKey
+	}
+	if path == "~/.config/bast/vault-passphrase" {
+		return filepath.Join(filepath.Dir(e.Paths.StateFile), "vault-passphrase")
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(e.Paths.Home, path[2:])
+	}
+	return path
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/apps/bast/internal/doctor/report.go
+++ b/apps/bast/internal/doctor/report.go
@@ -1,0 +1,350 @@
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/term"
+)
+
+type Severity string
+
+const (
+	SeverityFail Severity = "fail"
+	SeverityWarn Severity = "warn"
+	SeverityInfo Severity = "info"
+	SeverityOK   Severity = "ok"
+)
+
+type Category string
+
+const (
+	CatEnv         Category = "env"
+	CatPermissions Category = "permissions"
+	CatSSHConfig   Category = "ssh_config"
+	CatKeys        Category = "keys"
+	CatAgent       Category = "agent"
+	CatKnownHosts  Category = "known_hosts"
+	CatMetadata    Category = "metadata"
+	CatVault       Category = "vault"
+	CatSync        Category = "sync"
+	CatSuggest     Category = "suggest"
+	CatProbe       Category = "probe"
+)
+
+var categoryOrder = []Category{
+	CatEnv, CatPermissions, CatSSHConfig, CatKeys, CatAgent, CatKnownHosts,
+	CatMetadata, CatVault, CatSync, CatSuggest, CatProbe,
+}
+
+var categoryTitles = map[Category]string{
+	CatEnv:         "OpenSSH",
+	CatPermissions: "Permissions",
+	CatSSHConfig:   "SSH config",
+	CatKeys:        "Keys",
+	CatAgent:       "Agent",
+	CatKnownHosts:  "Known hosts",
+	CatMetadata:    "Metadata",
+	CatVault:       "Vault",
+	CatSync:        "Sync",
+	CatSuggest:     "Suggestions",
+	CatProbe:       "Connectivity",
+}
+
+type Finding struct {
+	ID       string   `json:"id"`
+	Severity Severity `json:"severity"`
+	Category Category `json:"category"`
+	Title    string   `json:"title"`
+	Detail   string   `json:"detail,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Line     int      `json:"line,omitempty"`
+	Host     string   `json:"host,omitempty"`
+	Fix      string   `json:"fix,omitempty"`
+	Fixable  bool     `json:"fixable"`
+}
+
+type Summary struct {
+	Fail int `json:"fail"`
+	Warn int `json:"warn"`
+	Info int `json:"info"`
+	OK   int `json:"ok"`
+}
+
+type Report struct {
+	Healthy  bool      `json:"healthy"`
+	Summary  Summary   `json:"summary"`
+	Findings []Finding `json:"findings"`
+	Fixed    []string  `json:"fixed,omitempty"`
+}
+
+func (r *Report) add(f Finding) {
+	r.Findings = append(r.Findings, f)
+}
+
+func (r *Report) finalize() {
+	if r.Findings == nil {
+		r.Findings = []Finding{}
+	}
+	r.Summary = Summary{}
+	for _, f := range r.Findings {
+		switch f.Severity {
+		case SeverityFail:
+			r.Summary.Fail++
+		case SeverityWarn:
+			r.Summary.Warn++
+		case SeverityInfo:
+			r.Summary.Info++
+		case SeverityOK:
+			r.Summary.OK++
+		}
+	}
+	r.Healthy = r.Summary.Fail == 0
+	sort.SliceStable(r.Findings, func(i, j int) bool {
+		a, b := r.Findings[i], r.Findings[j]
+		if a.Category != b.Category {
+			return categoryIndex(a.Category) < categoryIndex(b.Category)
+		}
+		if sa, sb := severityRank(a.Severity), severityRank(b.Severity); sa != sb {
+			return sa < sb
+		}
+		if a.Host != b.Host {
+			return a.Host < b.Host
+		}
+		return a.ID < b.ID
+	})
+}
+
+func (r *Report) filter(categories []string) {
+	if len(categories) == 0 {
+		return
+	}
+	allow := map[Category]bool{}
+	for _, c := range categories {
+		allow[Category(c)] = true
+	}
+	out := r.Findings[:0]
+	for _, f := range r.Findings {
+		if allow[f.Category] {
+			out = append(out, f)
+		}
+	}
+	r.Findings = out
+}
+
+func (r Report) HasFail() bool { return r.Summary.Fail > 0 }
+
+func categoryIndex(c Category) int {
+	for i, item := range categoryOrder {
+		if item == c {
+			return i
+		}
+	}
+	return len(categoryOrder)
+}
+
+func severityRank(s Severity) int {
+	switch s {
+	case SeverityFail:
+		return 0
+	case SeverityWarn:
+		return 1
+	case SeverityInfo:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func ValidCategory(name string) bool {
+	_, ok := categoryTitles[Category(name)]
+	return ok
+}
+
+func CategoryTitle(c Category) string {
+	if title, ok := categoryTitles[c]; ok {
+		return title
+	}
+	return string(c)
+}
+
+type formatStyles struct {
+	chip   lipgloss.Style
+	active lipgloss.Style
+	muted  lipgloss.Style
+	fail   lipgloss.Style
+	ok     lipgloss.Style
+	warn   lipgloss.Style
+	text   lipgloss.Style
+}
+
+func tuiStyles() formatStyles {
+	primary := lipgloss.Color("#8B5CF6")
+	muted := lipgloss.Color("#6B7280")
+	return formatStyles{
+		chip:   lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFFFFF")).Background(primary),
+		active: lipgloss.NewStyle().Bold(true).Foreground(primary),
+		muted:  lipgloss.NewStyle().Foreground(muted),
+		fail:   lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")),
+		ok:     lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981")),
+		warn:   lipgloss.NewStyle().Bold(true),
+		text:   lipgloss.NewStyle(),
+	}
+}
+
+func Format(w io.Writer, r Report) error {
+	_, err := lipgloss.Fprint(w, render(r, outputWidth(w)))
+	return err
+}
+
+func render(r Report, width int) string {
+	s := tuiStyles()
+	indent := 8
+	wrapAt := max(24, width-indent-2)
+	var b strings.Builder
+	b.WriteString(s.chip.Render(" BAST "))
+	b.WriteString("  ")
+	b.WriteString(s.muted.Render("doctor"))
+	b.WriteByte('\n')
+	if len(r.Fixed) > 0 {
+		b.WriteByte('\n')
+		b.WriteString(s.ok.Render("Repaired"))
+		b.WriteByte('\n')
+		for _, item := range r.Fixed {
+			b.WriteString(s.muted.Render("  " + item))
+			b.WriteByte('\n')
+		}
+	}
+	current := Category("")
+	for _, f := range r.Findings {
+		if f.Category != current {
+			b.WriteByte('\n')
+			current = f.Category
+			b.WriteString(s.active.Render(CategoryTitle(current)))
+			b.WriteString("\n\n")
+		}
+		sevStyle, titleStyle := severityStyles(s, f.Severity)
+		b.WriteString("  ")
+		b.WriteString(sevStyle.Render(padSev(f.Severity)))
+		b.WriteString("  ")
+		b.WriteString(titleStyle.Render(f.Title))
+		b.WriteByte('\n')
+		if loc := location(f); loc != "" {
+			b.WriteString(s.muted.Render(strings.Repeat(" ", indent) + loc))
+			b.WriteByte('\n')
+		}
+		if f.Detail != "" {
+			for _, line := range wrapWords(f.Detail, wrapAt) {
+				b.WriteString(s.muted.Render(strings.Repeat(" ", indent) + line))
+				b.WriteByte('\n')
+			}
+		}
+		if f.Fix != "" && f.Severity != SeverityOK {
+			text := f.Fix
+			if f.Fixable {
+				text = "Fix: " + f.Fix
+			}
+			for _, line := range wrapWords(text, wrapAt) {
+				b.WriteString(s.muted.Render(strings.Repeat(" ", indent) + line))
+				b.WriteByte('\n')
+			}
+		}
+	}
+	b.WriteByte('\n')
+	b.WriteString(renderSummary(s, r))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func severityStyles(s formatStyles, sev Severity) (label, title lipgloss.Style) {
+	switch sev {
+	case SeverityFail:
+		return s.fail, s.fail
+	case SeverityOK:
+		return s.ok, s.ok
+	case SeverityWarn:
+		return s.warn, s.text
+	default:
+		return s.muted, s.muted
+	}
+}
+
+func padSev(sev Severity) string {
+	label := string(sev)
+	if n := 4 - len(label); n > 0 {
+		label += strings.Repeat(" ", n)
+	}
+	return label
+}
+
+func renderSummary(s formatStyles, r Report) string {
+	if r.Summary.Fail == 0 && r.Summary.Warn == 0 && r.Summary.Info == 0 {
+		return s.ok.Render("No issues found")
+	}
+	var parts []string
+	if r.Summary.Fail > 0 {
+		parts = append(parts, s.fail.Render(fmt.Sprintf("%d failed", r.Summary.Fail)))
+	}
+	if r.Summary.Warn > 0 {
+		parts = append(parts, s.warn.Render(fmt.Sprintf("%d warnings", r.Summary.Warn)))
+	}
+	if r.Summary.Info > 0 {
+		parts = append(parts, s.muted.Render(fmt.Sprintf("%d suggestions", r.Summary.Info)))
+	}
+	return strings.Join(parts, s.muted.Render(", "))
+}
+
+func outputWidth(w io.Writer) int {
+	const fallback = 80
+	file, ok := w.(*os.File)
+	if !ok {
+		return fallback
+	}
+	cols, _, err := term.GetSize(file.Fd())
+	if err != nil || cols < 48 {
+		return fallback
+	}
+	return cols
+}
+
+func location(f Finding) string {
+	if f.Path == "" {
+		return ""
+	}
+	if f.Line > 0 {
+		return fmt.Sprintf("%s:%d", f.Path, f.Line)
+	}
+	return f.Path
+}
+
+func wrapWords(text string, width int) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	words := strings.Fields(text)
+	var lines []string
+	var current strings.Builder
+	for _, word := range words {
+		if current.Len() == 0 {
+			current.WriteString(word)
+			continue
+		}
+		if current.Len()+1+len(word) > width {
+			lines = append(lines, current.String())
+			current.Reset()
+			current.WriteString(word)
+			continue
+		}
+		current.WriteByte(' ')
+		current.WriteString(word)
+	}
+	if current.Len() > 0 {
+		lines = append(lines, current.String())
+	}
+	return lines
+}

--- a/apps/bast/internal/sshconfig/inspect.go
+++ b/apps/bast/internal/sshconfig/inspect.go
@@ -1,0 +1,352 @@
+package sshconfig
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Inspection is a diagnostic walk of SSH config. Unlike Discover, it keeps
+// duplicate aliases, wildcard Host lines, Match blocks, and include scoping.
+type Inspection struct {
+	Files       []InspectFile
+	Includes    []InspectInclude
+	Hosts       []InspectHost
+	Matches     []InspectMatch
+	ParseErrors []InspectError
+}
+
+type InspectFile struct {
+	Path    string
+	Missing bool
+	CRLF    bool
+	BOM     bool
+}
+
+type InspectInclude struct {
+	Source   string
+	Line     int
+	Pattern  string
+	Expanded string
+	Matches  []string
+	TopLevel bool
+	Scope    string // Host alias or Match spec when not top-level
+	Depth    int
+	Cycle    bool
+	Deep     bool
+	Empty    bool
+}
+
+type InspectHost struct {
+	Alias               string
+	Source              string
+	Line                int
+	Wildcard            bool
+	HostName            string
+	User                string
+	Port                string
+	IdentityFiles       []string
+	RawIdentityFiles    []string
+	IdentitiesOnly      string
+	ProxyJump           string
+	ForwardAgent        string
+	CertificateFile     string
+	ServerAliveInterval string
+	ControlPath         string
+	ControlMaster       string
+	UseKeychain         string
+	AddKeysToAgent      string
+	Managed             bool
+	ManagedID           string
+	Synced              bool
+	SyncSource          string
+	SyncID              string
+}
+
+type InspectMatch struct {
+	Source string
+	Line   int
+	Spec   string
+}
+
+type InspectError struct {
+	Path    string
+	Line    int
+	Code    string
+	Message string
+}
+
+// Inspect walks the main SSH config and every Include without stopping on the
+// first cycle or parse problem. Discovery behavior is unchanged.
+func (m Manager) Inspect() Inspection {
+	var ins Inspection
+	if _, err := os.Stat(m.MainConfig); os.IsNotExist(err) {
+		ins.Files = append(ins.Files, InspectFile{Path: m.MainConfig, Missing: true})
+		return ins
+	} else if err != nil {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: m.MainConfig, Code: "read", Message: err.Error()})
+		return ins
+	}
+	stack := map[string]bool{}
+	m.inspectFile(m.MainConfig, 0, stack, &ins)
+	return ins
+}
+
+func (m Manager) inspectFile(pathName string, depth int, stack map[string]bool, ins *Inspection) {
+	abs, err := filepath.Abs(pathName)
+	if err != nil {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: pathName, Code: "path", Message: err.Error()})
+		return
+	}
+	if depth > 8 {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Code: "include_depth", Message: "SSH config include depth exceeded"})
+		return
+	}
+	if stack[abs] {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Code: "include_cycle", Message: "cyclic SSH config include"})
+		return
+	}
+	b, err := os.ReadFile(abs)
+	if os.IsNotExist(err) {
+		ins.Files = append(ins.Files, InspectFile{Path: abs, Missing: true})
+		return
+	}
+	if err != nil {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Code: "read", Message: err.Error()})
+		return
+	}
+	file := InspectFile{Path: abs, BOM: bytes.HasPrefix(b, []byte{0xEF, 0xBB, 0xBF}), CRLF: bytes.Contains(b, []byte("\r\n"))}
+	ins.Files = append(ins.Files, file)
+	if file.BOM {
+		b = b[3:]
+	}
+	stack[abs] = true
+	defer delete(stack, abs)
+
+	inBlock := false
+	scope := ""
+	var active []int
+	managedID := ""
+	managedOpenLine := 0
+	syncSource, syncID := "", ""
+	syncOpenLine := 0
+	baseDir := filepath.Dir(abs)
+	includeBase := filepath.Dir(m.MainConfig)
+	if includeBase == "" {
+		includeBase = baseDir
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		rawLine := scanner.Text()
+		raw := strings.TrimSpace(rawLine)
+		if strings.HasPrefix(raw, markerPrefix) {
+			if managedID != "" {
+				ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: managedOpenLine, Code: "marker_unclosed", Message: "Bast managed block was not closed before the next # bast:id="})
+			}
+			managedID = strings.TrimSpace(strings.TrimPrefix(raw, markerPrefix))
+			managedOpenLine = lineNo
+			continue
+		}
+		if raw == markerEnd {
+			managedID = ""
+			managedOpenLine = 0
+			continue
+		}
+		if strings.HasPrefix(raw, syncMarkerPrefix) {
+			if raw == syncMarkerEnd {
+				syncSource, syncID = "", ""
+				syncOpenLine = 0
+			} else {
+				if syncID != "" {
+					ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: syncOpenLine, Code: "marker_unclosed", Message: "Bast sync block was not closed before the next # bast:sync: marker"})
+				}
+				rest := strings.TrimPrefix(raw, syncMarkerPrefix)
+				if source, id, ok := strings.Cut(rest, "="); ok {
+					syncSource = strings.TrimSpace(source)
+					syncID = strings.TrimSpace(id)
+					syncOpenLine = lineNo
+				}
+			}
+			continue
+		}
+		parsed, ferr := fields(raw)
+		if ferr != nil {
+			ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: lineNo, Code: "parse", Message: ferr.Error()})
+			continue
+		}
+		if len(parsed) == 0 {
+			continue
+		}
+		switch strings.ToLower(parsed[0]) {
+		case "include":
+			for _, pattern := range parsed[1:] {
+				expanded := expandPath(pattern, m.Home, includeBase)
+				inc := InspectInclude{
+					Source: abs, Line: lineNo, Pattern: pattern, Expanded: expanded,
+					TopLevel: !inBlock, Scope: scope, Depth: depth,
+				}
+				matches, globErr := filepath.Glob(expanded)
+				if globErr != nil {
+					inc.Empty = true
+					ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: lineNo, Code: "include_glob", Message: globErr.Error()})
+					ins.Includes = append(ins.Includes, inc)
+					continue
+				}
+				inc.Matches = append([]string(nil), matches...)
+				if len(matches) == 0 {
+					inc.Empty = true
+				}
+				ins.Includes = append(ins.Includes, inc)
+				idx := len(ins.Includes) - 1
+				for _, match := range matches {
+					matchAbs, _ := filepath.Abs(match)
+					if matchAbs == "" {
+						matchAbs = match
+					}
+					if stack[matchAbs] {
+						ins.Includes[idx].Cycle = true
+						ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: lineNo, Code: "include_cycle", Message: "cyclic SSH config include at " + matchAbs})
+						continue
+					}
+					if depth+1 > 8 {
+						ins.Includes[idx].Deep = true
+						ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: lineNo, Code: "include_depth", Message: "SSH config include depth exceeded at " + matchAbs})
+						continue
+					}
+					m.inspectFile(match, depth+1, stack, ins)
+				}
+			}
+		case "host":
+			inBlock = true
+			active = active[:0]
+			aliases := parsed[1:]
+			if len(aliases) > 0 {
+				scope = aliases[0]
+			}
+			for _, alias := range aliases {
+				h := InspectHost{
+					Alias: alias, Source: abs, Line: lineNo,
+					Wildcard: !selectableAlias(alias),
+					Managed:  abs == m.ManagedConfig && managedID != "", ManagedID: managedID,
+					Synced: syncID != "", SyncSource: syncSource, SyncID: syncID,
+				}
+				ins.Hosts = append(ins.Hosts, h)
+				active = append(active, len(ins.Hosts)-1)
+			}
+		case "match":
+			inBlock = true
+			active = nil
+			spec := strings.Join(parsed[1:], " ")
+			scope = spec
+			ins.Matches = append(ins.Matches, InspectMatch{Source: abs, Line: lineNo, Spec: spec})
+		default:
+			if len(active) == 0 || len(parsed) < 2 {
+				continue
+			}
+			applyInspectDirective(ins.Hosts, active, parsed, m.Home, baseDir)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Code: "scan", Message: err.Error()})
+	}
+	if managedID != "" {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: managedOpenLine, Code: "marker_unclosed", Message: "Bast managed block is missing # bast:end"})
+	}
+	if syncID != "" {
+		ins.ParseErrors = append(ins.ParseErrors, InspectError{Path: abs, Line: syncOpenLine, Code: "marker_unclosed", Message: "Bast sync block is missing # bast:sync:end"})
+	}
+}
+
+func applyInspectDirective(hosts []InspectHost, active []int, parsed []string, home, baseDir string) {
+	key := strings.ToLower(parsed[0])
+	value := parsed[1]
+	joined := strings.Join(parsed[1:], " ")
+	for _, idx := range active {
+		h := &hosts[idx]
+		switch key {
+		case "hostname":
+			if h.HostName == "" {
+				h.HostName = value
+			}
+		case "user":
+			if h.User == "" {
+				h.User = value
+			}
+		case "port":
+			if h.Port == "" {
+				h.Port = value
+			}
+		case "identityfile":
+			h.IdentityFiles = append(h.IdentityFiles, expandPath(value, home, baseDir))
+			h.RawIdentityFiles = append(h.RawIdentityFiles, value)
+		case "identitiesonly":
+			if h.IdentitiesOnly == "" {
+				h.IdentitiesOnly = value
+			}
+		case "proxyjump":
+			if h.ProxyJump == "" {
+				h.ProxyJump = value
+			}
+		case "forwardagent":
+			if h.ForwardAgent == "" {
+				h.ForwardAgent = value
+			}
+		case "certificatefile":
+			if h.CertificateFile == "" {
+				h.CertificateFile = expandPath(value, home, baseDir)
+			}
+		case "serveraliveinterval":
+			if h.ServerAliveInterval == "" {
+				h.ServerAliveInterval = value
+			}
+		case "controlpath":
+			if h.ControlPath == "" {
+				h.ControlPath = joined
+			}
+		case "controlmaster":
+			if h.ControlMaster == "" {
+				h.ControlMaster = value
+			}
+		case "usekeychain":
+			if h.UseKeychain == "" {
+				h.UseKeychain = value
+			}
+		case "addkeystoagent":
+			if h.AddKeysToAgent == "" {
+				h.AddKeysToAgent = value
+			}
+		}
+	}
+}
+
+func includeTargets(inc InspectInclude, target string) bool {
+	if target == "" {
+		return false
+	}
+	want := cleanPath(target)
+	if cleanPath(inc.Expanded) == want {
+		return true
+	}
+	for _, match := range inc.Matches {
+		if cleanPath(match) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// HostPatternMatch reports whether an SSH Host pattern matches name.
+func HostPatternMatch(pattern, name string) bool {
+	if pattern == "" || strings.HasPrefix(pattern, "!") {
+		return false
+	}
+	ok, err := path.Match(pattern, name)
+	return err == nil && ok
+}

--- a/apps/bast/internal/sshconfig/inspect_test.go
+++ b/apps/bast/internal/sshconfig/inspect_test.go
@@ -1,0 +1,117 @@
+package sshconfig
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectKeepsDuplicatesWildcardsAndScopedIncludes(t *testing.T) {
+	m := testManager(t)
+	writeTestFile(t, m.MainConfig, strings.Join([]string{
+		"Host work",
+		"  HostName work.example",
+		"  Include " + filepath.ToSlash(filepath.Join(m.Home, ".ssh", "bast", "config")),
+		"Host prod",
+		"  HostName first.example",
+		"Host prod",
+		"  HostName second.example",
+		"Host *.wild",
+		"  User deploy",
+		"Match host extra",
+		"  User other",
+	}, "\n")+"\n", 0600)
+	writeTestFile(t, m.ManagedConfig, "Host managed\n  HostName managed.example\n", 0600)
+
+	ins := m.Inspect()
+	if len(ins.ParseErrors) != 0 {
+		t.Fatalf("parse errors: %+v", ins.ParseErrors)
+	}
+	var scoped, topLevel int
+	for _, inc := range ins.Includes {
+		if includeTargets(inc, m.ManagedConfig) {
+			if inc.TopLevel {
+				topLevel++
+			} else {
+				scoped++
+				if inc.Scope != "work" {
+					t.Fatalf("scoped include scope = %q", inc.Scope)
+				}
+			}
+		}
+	}
+	if scoped != 1 || topLevel != 0 {
+		t.Fatalf("includes scoped=%d topLevel=%d: %+v", scoped, topLevel, ins.Includes)
+	}
+
+	var prods, wildcards, managed int
+	for _, h := range ins.Hosts {
+		switch {
+		case h.Alias == "prod":
+			prods++
+		case h.Wildcard && h.Alias == "*.wild":
+			wildcards++
+		case h.Alias == "managed":
+			managed++
+		}
+	}
+	if prods != 2 {
+		t.Fatalf("expected 2 prod occurrences, hosts=%+v", aliases(ins))
+	}
+	if wildcards != 1 || managed != 1 {
+		t.Fatalf("wildcard=%d managed=%d aliases=%v", wildcards, managed, aliases(ins))
+	}
+	if len(ins.Matches) != 1 || ins.Matches[0].Spec != "host extra" {
+		t.Fatalf("matches = %+v", ins.Matches)
+	}
+}
+
+func TestInspectRecordsCyclesWithoutAborting(t *testing.T) {
+	m := testManager(t)
+	writeTestFile(t, m.MainConfig, "Include loop.conf\nHost after\n  HostName after.example\n", 0600)
+	writeTestFile(t, filepath.Join(filepath.Dir(m.MainConfig), "loop.conf"), "Include config\n", 0600)
+	ins := m.Inspect()
+	foundCycle := false
+	for _, err := range ins.ParseErrors {
+		if err.Code == "include_cycle" {
+			foundCycle = true
+		}
+	}
+	if !foundCycle {
+		t.Fatalf("expected cycle error, got %+v", ins.ParseErrors)
+	}
+	foundAfter := false
+	for _, h := range ins.Hosts {
+		if h.Alias == "after" {
+			foundAfter = true
+		}
+	}
+	if !foundAfter {
+		t.Fatalf("cycle should not hide later hosts: %v", aliases(ins))
+	}
+}
+
+func TestInspectMissingMainConfig(t *testing.T) {
+	m := testManager(t)
+	ins := m.Inspect()
+	if len(ins.Files) != 1 || !ins.Files[0].Missing {
+		t.Fatalf("files = %+v", ins.Files)
+	}
+}
+
+func TestHostPatternMatch(t *testing.T) {
+	if !HostPatternMatch("*", "prod") || !HostPatternMatch("prod", "prod") || HostPatternMatch("prod", "other") {
+		t.Fatal("literal and star matching failed")
+	}
+	if !HostPatternMatch("*.example", "api.example") || HostPatternMatch("*.example", "api") {
+		t.Fatal("wildcard matching failed")
+	}
+}
+
+func aliases(ins Inspection) []string {
+	out := make([]string, 0, len(ins.Hosts))
+	for _, h := range ins.Hosts {
+		out = append(out, h.Alias)
+	}
+	return out
+}

--- a/apps/bast/internal/ui/app.go
+++ b/apps/bast/internal/ui/app.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"bast/internal/cloud/sync"
+	"bast/internal/doctor"
 	"bast/internal/history"
 	"bast/internal/keys"
 	"bast/internal/metadata"
@@ -181,6 +182,10 @@ type App struct {
 	help                bool
 	helpOffset          int
 	credits             bool
+	doctor              bool
+	doctorOffset        int
+	doctorLoading       bool
+	doctorReport        doctor.Report
 	showHidden          bool
 	loading             bool
 	enriching           bool
@@ -428,6 +433,9 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.help {
 			m.clampHelpOffset()
 		}
+		if m.doctor {
+			m.clampDoctorOffset()
+		}
 		return m, nil
 	case tea.BackgroundColorMsg:
 		m.dark = msg.IsDark()
@@ -461,6 +469,14 @@ func (m *App) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.autoSyncCmds(), m.setNotice(fmt.Sprintf("%d host details could not be resolved", msg.enrichmentErrors)))
 		}
 		return m, m.autoSyncCmds()
+	case doctorDoneMsg:
+		if !m.doctor {
+			return m, nil
+		}
+		m.doctorLoading = false
+		m.doctorReport = msg.report
+		m.clampDoctorOffset()
+		return m, nil
 	case discoveredMsg:
 		if msg.err != nil {
 			m.loading = false

--- a/apps/bast/internal/ui/app_test.go
+++ b/apps/bast/internal/ui/app_test.go
@@ -20,6 +20,7 @@ import (
 
 	cloudsync "bast/internal/cloud/sync"
 	"bast/internal/connectbanner"
+	"bast/internal/doctor"
 	keymodel "bast/internal/keys"
 	"bast/internal/metadata"
 	"bast/internal/openssh"
@@ -173,6 +174,7 @@ func TestCtrlCQuitsFromEveryBastContext(t *testing.T) {
 		"root":   func(*App) {},
 		"help":   func(m *App) { m.help = true },
 		"about":  func(m *App) { m.credits = true },
+		"doctor": func(m *App) { m.doctor = true },
 		"search": func(m *App) { m.search = "\x00query" },
 		"error":  func(m *App) { m.status, m.statusError = "failed", true },
 		"host form": func(m *App) {
@@ -193,11 +195,12 @@ func TestCtrlCQuitsFromEveryBastContext(t *testing.T) {
 }
 
 func TestQQuitsOutsideTextInput(t *testing.T) {
-	for _, context := range []string{"root", "help", "about"} {
+	for _, context := range []string{"root", "help", "about", "doctor"} {
 		t.Run(context, func(t *testing.T) {
 			m := testApp(t)
 			m.help = context == "help"
 			m.credits = context == "about"
+			m.doctor = context == "doctor"
 			_, cmd := m.Update(press("q"))
 			requireQuit(t, cmd)
 		})
@@ -2327,6 +2330,42 @@ func TestHelpScreenIsSpacedAndScrollable(t *testing.T) {
 	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
 	if m.help || m.helpOffset != 0 {
 		t.Fatalf("Esc should close help and reset scroll: help=%v offset=%d", m.help, m.helpOffset)
+	}
+}
+
+func TestDoctorOpensOutsideFilesAndCloses(t *testing.T) {
+	m := testApp(t)
+	m.width, m.height = 80, 24
+	_, cmd := m.Update(press("D"))
+	if !m.doctor || m.help || cmd == nil {
+		t.Fatalf("D should open doctor: doctor=%v help=%v cmd=%v", m.doctor, m.help, cmd)
+	}
+	m.Update(doctorDoneMsg{report: doctor.Report{
+		Healthy: true,
+		Findings: []doctor.Finding{{
+			ID: "env.openssh_ok", Severity: doctor.SeverityOK, Category: doctor.CatEnv, Title: "ssh ok",
+		}},
+	}})
+	if m.doctorLoading {
+		t.Fatal("doctor should finish loading")
+	}
+	rendered := m.render()
+	if !strings.Contains(rendered, "Doctor") || !strings.Contains(rendered, "ssh ok") {
+		t.Fatalf("doctor overlay missing content:\n%s", rendered)
+	}
+	m.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	if m.doctor {
+		t.Fatal("Esc did not close doctor")
+	}
+}
+
+func TestFilesDDoesNotOpenDoctor(t *testing.T) {
+	m := testApp(t)
+	m.section = filesSection
+	m.initFilesState()
+	m.Update(press("D"))
+	if m.doctor {
+		t.Fatal("D on Files opened doctor")
 	}
 }
 

--- a/apps/bast/internal/ui/doctor.go
+++ b/apps/bast/internal/ui/doctor.go
@@ -1,0 +1,179 @@
+package ui
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"bast/internal/doctor"
+)
+
+type doctorDoneMsg struct {
+	report doctor.Report
+}
+
+func (m *App) openDoctor() tea.Cmd {
+	m.help, m.credits, m.helpOffset = false, false, 0
+	m.doctor, m.doctorOffset, m.doctorLoading = true, 0, true
+	m.doctorReport = doctor.Report{}
+	return m.doctorCmd()
+}
+
+func (m *App) doctorCmd() tea.Cmd {
+	p, client, version := m.paths, m.openSSH, m.version
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+		defer cancel()
+		return doctorDoneMsg{report: doctor.New(p, client, version).Run(ctx, doctor.Options{})}
+	}
+}
+
+func (m *App) closeDoctor() {
+	m.doctor, m.doctorLoading, m.doctorOffset = false, false, 0
+}
+
+func (m *App) doctorLines(s styleSet) []string {
+	width := m.helpContentWidth()
+	lines := []string{"", s.active.Render("Doctor"), ""}
+	if m.doctorLoading {
+		return append(lines, s.muted.Render("Checking SSH setup…"))
+	}
+	if len(m.doctorReport.Fixed) > 0 {
+		lines = append(lines, s.success.Render("Repaired"))
+		for _, item := range m.doctorReport.Fixed {
+			lines = append(lines, s.muted.Render("  "+item))
+		}
+		lines = append(lines, "")
+	}
+	current := doctor.Category("")
+	for _, f := range m.doctorReport.Findings {
+		if f.Category != current {
+			if current != "" {
+				lines = append(lines, "")
+			}
+			current = f.Category
+			lines = append(lines, s.active.Render(doctor.CategoryTitle(current)), "")
+		}
+		sev := s.muted
+		switch f.Severity {
+		case doctor.SeverityFail:
+			sev = s.error
+		case doctor.SeverityWarn:
+			sev = s.value
+		case doctor.SeverityOK:
+			sev = s.success
+		}
+		title := f.Title
+		if f.Path != "" {
+			loc := f.Path
+			if f.Line > 0 {
+				loc += ":" + strconv.Itoa(f.Line)
+			}
+			title += " (" + loc + ")"
+		}
+		lines = append(lines, sev.Render(padRight(string(f.Severity), 5)+" "+truncate(title, max(8, width-8))))
+		if f.Detail != "" {
+			for _, line := range wrapPlain(f.Detail, max(12, width-6)) {
+				lines = append(lines, s.muted.Render("      "+line))
+			}
+		}
+		if f.Fix != "" && f.Severity != doctor.SeverityOK {
+			for _, line := range wrapPlain(f.Fix, max(12, width-6)) {
+				lines = append(lines, s.muted.Render("      "+line))
+			}
+		}
+	}
+	if !m.doctorLoading {
+		lines = append(lines, "", s.muted.Render(doctorSummary(m.doctorReport)))
+	}
+	return lines
+}
+
+func doctorSummary(r doctor.Report) string {
+	if r.Summary.Fail == 0 && r.Summary.Warn == 0 && r.Summary.Info == 0 {
+		return "No issues found"
+	}
+	var parts []string
+	if r.Summary.Fail > 0 {
+		parts = append(parts, strconv.Itoa(r.Summary.Fail)+" failed")
+	}
+	if r.Summary.Warn > 0 {
+		parts = append(parts, strconv.Itoa(r.Summary.Warn)+" warnings")
+	}
+	if r.Summary.Info > 0 {
+		parts = append(parts, strconv.Itoa(r.Summary.Info)+" suggestions")
+	}
+	return strings.Join(parts, ", ") + " · bast doctor --fix repairs a few of these"
+}
+
+func (m *App) renderDoctor(s styleSet) string {
+	lines := m.doctorLines(s)
+	bodyHeight := m.helpBodyHeight()
+	offset := min(max(0, m.doctorOffset), max(0, len(lines)-bodyHeight))
+	end := min(len(lines), offset+bodyHeight)
+	content := lipgloss.NewStyle().
+		MarginLeft(2).
+		Render(strings.Join(lines[offset:end], "\n"))
+	return lipgloss.Place(m.terminalWidth(), bodyHeight, lipgloss.Left, lipgloss.Top, content)
+}
+
+func (m *App) maxDoctorOffset() int {
+	return max(0, len(m.doctorLines(m.styles()))-m.helpBodyHeight())
+}
+
+func (m *App) clampDoctorOffset() {
+	if m.doctorOffset < 0 {
+		m.doctorOffset = 0
+	}
+	if maxOffset := m.maxDoctorOffset(); m.doctorOffset > maxOffset {
+		m.doctorOffset = maxOffset
+	}
+}
+
+func (m *App) scrollDoctor(delta int) {
+	m.doctorOffset += delta
+	m.clampDoctorOffset()
+}
+
+func (m *App) doctorCanScroll() bool {
+	return m.maxDoctorOffset() > 0
+}
+
+func padRight(value string, width int) string {
+	if len(value) >= width {
+		return value
+	}
+	return value + strings.Repeat(" ", width-len(value))
+}
+
+func wrapPlain(text string, width int) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	words := strings.Fields(text)
+	var lines []string
+	var current strings.Builder
+	for _, word := range words {
+		if current.Len() == 0 {
+			current.WriteString(word)
+			continue
+		}
+		if current.Len()+1+len(word) > width {
+			lines = append(lines, current.String())
+			current.Reset()
+			current.WriteString(word)
+			continue
+		}
+		current.WriteByte(' ')
+		current.WriteString(word)
+	}
+	if current.Len() > 0 {
+		lines = append(lines, current.String())
+	}
+	return lines
+}

--- a/apps/bast/internal/ui/input.go
+++ b/apps/bast/internal/ui/input.go
@@ -76,7 +76,7 @@ func (c *connectionProcess) SetStderr(output io.Writer) {
 
 func (m *App) updateMouse(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	mouse := msg.Mouse()
-	if mouse.Button != tea.MouseLeft || m.help || m.credits || (m.statusError && m.status != "") {
+	if mouse.Button != tea.MouseLeft || m.help || m.credits || m.doctor || (m.statusError && m.status != "") {
 		return m, nil
 	}
 	m.scrollbarDragging = false
@@ -205,6 +205,15 @@ func (m *App) updateMouseMotion(msg tea.MouseMotionMsg) (tea.Model, tea.Cmd) {
 
 func (m *App) updateMouseWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
 	if m.credits || m.form != nil {
+		return m, nil
+	}
+	if m.doctor {
+		switch msg.Mouse().Button {
+		case tea.MouseWheelUp:
+			m.scrollDoctor(-3)
+		case tea.MouseWheelDown:
+			m.scrollDoctor(3)
+		}
 		return m, nil
 	}
 	if m.help {

--- a/apps/bast/internal/ui/keymap.go
+++ b/apps/bast/internal/ui/keymap.go
@@ -21,6 +21,14 @@ const (
 	ActionHelpBottom
 	ActionCreditsOpen
 	ActionCreditsClose
+	ActionDoctorOpen
+	ActionDoctorClose
+	ActionDoctorScrollUp
+	ActionDoctorScrollDown
+	ActionDoctorPageUp
+	ActionDoctorPageDown
+	ActionDoctorTop
+	ActionDoctorBottom
 	ActionTabHosts
 	ActionTabKeys
 	ActionTabVault
@@ -92,6 +100,7 @@ const (
 	ScopeGlobal Scope = iota
 	ScopeHelp
 	ScopeCredits
+	ScopeDoctor
 	ScopeHosts
 	ScopeKeys
 	ScopeVault
@@ -194,6 +203,9 @@ func (m *App) matchScopes() []Scope {
 	}
 	if m.credits {
 		return []Scope{ScopeCredits}
+	}
+	if m.doctor {
+		return []Scope{ScopeDoctor}
 	}
 	return []Scope{m.tabScope(), ScopeGlobal}
 }

--- a/apps/bast/internal/ui/keymap_catalog.go
+++ b/apps/bast/internal/ui/keymap_catalog.go
@@ -12,6 +12,7 @@ func buildCatalog() []Binding {
 	return []Binding{
 		// Help overlay (content describes browse; these keys operate the overlay).
 		bind(ActionCreditsOpen, []string{"v"}, ScopeHelp, "About", "").noHelp(),
+		bind(ActionDoctorOpen, []string{"D"}, ScopeHelp, "Doctor", "").noHelp(),
 		bind(ActionQuit, []string{"q"}, ScopeHelp, "Quit", "").noHelp(),
 		bind(ActionHelpClose, []string{"?", "esc", "backspace", "ctrl+h"}, ScopeHelp, "Close", "close").chord("? / Esc / ⌫").withFooter(20).noHelp(),
 		bind(ActionHelpScrollUp, []string{"up", "k"}, ScopeHelp, "Scroll up", "").noHelp(),
@@ -24,14 +25,29 @@ func buildCatalog() []Binding {
 
 		// Credits.
 		bind(ActionHelpToggle, []string{"?"}, ScopeCredits, "Help", "").noHelp(),
+		bind(ActionDoctorOpen, []string{"D"}, ScopeCredits, "Doctor", "").noHelp(),
 		bind(ActionQuit, []string{"q"}, ScopeCredits, "Quit", "").noHelp(),
 		bind(ActionCreditsClose, []string{"v", "esc", "backspace", "ctrl+h"}, ScopeCredits, "Close", "close").chord("v / Esc / ⌫").withFooter(10).noHelp(),
+
+		// Doctor overlay.
+		bind(ActionHelpToggle, []string{"?"}, ScopeDoctor, "Help", "").noHelp(),
+		bind(ActionCreditsOpen, []string{"v"}, ScopeDoctor, "About", "").noHelp(),
+		bind(ActionQuit, []string{"q"}, ScopeDoctor, "Quit", "").noHelp(),
+		bind(ActionDoctorClose, []string{"D", "esc", "backspace", "ctrl+h"}, ScopeDoctor, "Close", "close").chord("D / Esc / ⌫").withFooter(20).noHelp(),
+		bind(ActionDoctorScrollUp, []string{"up", "k"}, ScopeDoctor, "Scroll up", "").noHelp(),
+		bind(ActionDoctorScrollDown, []string{"down", "j"}, ScopeDoctor, "Scroll down", "").noHelp(),
+		bind(ActionDoctorPageUp, []string{"pgup"}, ScopeDoctor, "Page up", "").noHelp(),
+		bind(ActionDoctorPageDown, []string{"pgdown"}, ScopeDoctor, "Page down", "").noHelp(),
+		bind(ActionDoctorTop, []string{"g", "home"}, ScopeDoctor, "Top", "").noHelp(),
+		bind(ActionDoctorBottom, []string{"G", "end"}, ScopeDoctor, "Bottom", "").noHelp(),
+		bind(ActionDoctorScrollDown, []string{"up", "down"}, ScopeDoctor, "Scroll", "scroll").chord("↑/↓").withFooter(10).when(func(m *App) bool { return m.doctorCanScroll() }).noHelp().skip(),
 
 		// Global browse.
 		bind(ActionQuit, []string{"ctrl+c"}, ScopeGlobal, "Quit", "").noHelp(),
 		bind(ActionQuit, []string{"q"}, ScopeGlobal, "Quit", ""),
 		bind(ActionQuit, []string{"esc", "backspace", "ctrl+h"}, ScopeGlobal, "Quit", "").noHelp(),
 		bind(ActionHelpToggle, []string{"?"}, ScopeGlobal, "Help", "").withFooter(1000),
+		bind(ActionDoctorOpen, []string{"D"}, ScopeGlobal, "Doctor", "").when(func(m *App) bool { return m.section != filesSection }),
 		bind(ActionTabHosts, []string{"1"}, ScopeGlobal, "Hosts", "").noHelp(),
 		bind(ActionTabKeys, []string{"2"}, ScopeGlobal, "Keys", "").noHelp(),
 		bind(ActionTabVault, []string{"3"}, ScopeGlobal, "Vault", "").noHelp(),

--- a/apps/bast/internal/ui/keymap_dispatch.go
+++ b/apps/bast/internal/ui/keymap_dispatch.go
@@ -13,6 +13,7 @@ func (m *App) dispatch(id Action) (tea.Model, tea.Cmd) {
 	case ActionQuit:
 		return m, tea.Quit
 	case ActionHelpToggle:
+		m.closeDoctor()
 		m.help, m.credits, m.helpOffset = true, false, 0
 		return m, nil
 	case ActionHelpClose:
@@ -37,10 +38,34 @@ func (m *App) dispatch(id Action) (tea.Model, tea.Cmd) {
 		m.helpOffset = m.maxHelpOffset()
 		return m, nil
 	case ActionCreditsOpen:
+		m.closeDoctor()
 		m.credits, m.help, m.helpOffset = true, false, 0
 		return m, nil
 	case ActionCreditsClose:
 		m.credits = false
+		return m, nil
+	case ActionDoctorOpen:
+		return m, m.openDoctor()
+	case ActionDoctorClose:
+		m.closeDoctor()
+		return m, nil
+	case ActionDoctorScrollUp:
+		m.scrollDoctor(-1)
+		return m, nil
+	case ActionDoctorScrollDown:
+		m.scrollDoctor(1)
+		return m, nil
+	case ActionDoctorPageUp:
+		m.scrollDoctor(-m.helpBodyHeight())
+		return m, nil
+	case ActionDoctorPageDown:
+		m.scrollDoctor(m.helpBodyHeight())
+		return m, nil
+	case ActionDoctorTop:
+		m.doctorOffset = 0
+		return m, nil
+	case ActionDoctorBottom:
+		m.doctorOffset = m.maxDoctorOffset()
 		return m, nil
 	case ActionTabHosts:
 		return m, m.switchToSection(hostsSection)

--- a/apps/bast/internal/ui/keymap_test.go
+++ b/apps/bast/internal/ui/keymap_test.go
@@ -74,6 +74,22 @@ func TestHelpUpScrollsUpNotDown(t *testing.T) {
 	}
 }
 
+func TestDoctorKeyDoesNotStealFilesDisconnect(t *testing.T) {
+	m := testApp(t)
+	if b, ok := m.matchBinding("D"); !ok || b.ID != ActionDoctorOpen {
+		t.Fatalf("hosts D = %+v ok=%v", b, ok)
+	}
+	m.section = filesSection
+	if b, ok := m.matchBinding("D"); !ok || b.ID != ActionFilesDisconnect {
+		t.Fatalf("files D = %+v ok=%v", b, ok)
+	}
+	m.section = hostsSection
+	m.doctor = true
+	if b, ok := m.matchBinding("esc"); !ok || b.ID != ActionDoctorClose {
+		t.Fatalf("doctor esc = %+v ok=%v", b, ok)
+	}
+}
+
 func TestSyncLMovesRight(t *testing.T) {
 	m := testApp(t)
 	m.section = syncSection

--- a/apps/bast/internal/ui/view.go
+++ b/apps/bast/internal/ui/view.go
@@ -70,6 +70,8 @@ func (m *App) render() string {
 		body = m.renderError(styles)
 	} else if m.credits {
 		body = m.renderCredits(styles)
+	} else if m.doctor {
+		body = m.renderDoctor(styles)
 	} else if m.help {
 		body = m.renderHelp(styles)
 	} else if m.form != nil {
@@ -109,6 +111,8 @@ func (m *App) renderError(s styleSet) string {
 	explanation := "The action did not complete."
 	if m.form != nil {
 		explanation += " Your entries are still available when you return."
+	} else {
+		explanation += " Run bast doctor for a full diagnosis."
 	}
 	footer := "Enter/Esc return"
 	if telemetry.Enabled() {
@@ -1097,6 +1101,13 @@ func (m *App) renderFooter(s styleSet) string {
 		hint := strings.Join(m.overlayFooterParts(ScopeCredits), " · ")
 		if hint == "" {
 			hint = "v / Esc / ⌫ close"
+		}
+		return strings.Repeat(" ", max(1, m.terminalWidth()-lipgloss.Width(hint))) + s.muted.Render(hint)
+	}
+	if m.doctor {
+		hint := strings.Join(m.overlayFooterParts(ScopeDoctor), " · ")
+		if hint == "" {
+			hint = "D / Esc / ⌫ close"
 		}
 		return strings.Repeat(" ", max(1, m.terminalWidth()-lipgloss.Width(hint))) + s.muted.Render(hint)
 	}

--- a/apps/web/app/cli/page.tsx
+++ b/apps/web/app/cli/page.tsx
@@ -104,12 +104,17 @@ export default async function CliPage() {
         <pre className="overflow-x-auto border border-border bg-surface px-4 py-3 font-mono text-xs text-foreground">
           {`bast hosts list --json
 bast keys list --json
+bast doctor --json
 bast --json hosts show production_web`}
         </pre>
         <p>
           Command reference:{" "}
           <Link href="/docs/features/cli" className={legalLinkClass}>
             Command line
+          </Link>
+          {" · "}
+          <Link href="/docs/features/doctor" className={legalLinkClass}>
+            Doctor
           </Link>
           . HTTP API for Vault lives at{" "}
           <Link href="/developers" className={legalLinkClass}>

--- a/apps/web/content/docs/features/(hosts)/ssh-config.mdx
+++ b/apps/web/content/docs/features/(hosts)/ssh-config.mdx
@@ -15,6 +15,8 @@ Include ~/.ssh/bast/config
 
 New hosts you create through Bast are written to that managed file. Everything else stays where it already lives.
 
+`Include` must stay above any `Host` or `Match` block. OpenSSH otherwise treats it as part of the preceding host, and Bast-managed hosts never apply. `bast doctor` flags that as `ssh_config.include_not_toplevel`.
+
 ## Discovery
 
 Bast discovers hosts from your main config and every file it includes. Externally managed blocks keep their original source path. Bast-managed blocks are marked so you know which ones it owns.

--- a/apps/web/content/docs/features/(other)/cli.mdx
+++ b/apps/web/content/docs/features/(other)/cli.mdx
@@ -5,6 +5,17 @@ description: Manage hosts and keys from the shell, with JSON output for scripts 
 
 Everything in the TUI is also available from the shell. That matters for scripts, automation, and tools that need stable output.
 
+## Doctor
+
+```bash
+bast doctor
+bast doctor --json
+bast doctor --fix
+bast doctor --probe
+```
+
+Diagnoses SSH config, keys, permissions, and Bast setup. Failures exit 1; warnings do not. See [Doctor](/docs/features/doctor).
+
 ## Host commands
 
 ```bash
@@ -87,6 +98,7 @@ Pass `--json` anywhere in the command for machine-readable output. It disables p
 bast hosts list --json
 bast --json hosts show production_web
 bast keys generate automation --no-passphrase --json
+bast doctor --json
 ```
 
 Success looks like `{"ok":true,"data":...}`. Errors go to stderr with a non-zero exit code. Commands that need an interactive SSH session or passphrase entry reject `--json` with `interactive_required`.

--- a/apps/web/content/docs/features/(other)/doctor.mdx
+++ b/apps/web/content/docs/features/(other)/doctor.mdx
@@ -1,0 +1,69 @@
+---
+title: Doctor
+description: Diagnose SSH config, keys, permissions, and Bast setup with bast doctor.
+---
+
+`bast doctor` inspects the OpenSSH layout Bast actually uses. It reports problems that make hosts disappear, authentication fail, or Bast look empty, then suggests what to do next.
+
+```bash
+bast doctor
+bast doctor --json
+bast doctor --fix
+bast doctor --probe
+bast doctor --category ssh_config
+```
+
+In the TUI, press `D` from Hosts, Keys, Vault, Sync, help, or About. Files keeps `D` for disconnect.
+
+Doctor does not run on every launch. It does not open SSH sessions. It never prints private keys, passphrases, Vault tokens, or the Upstash API key.
+
+On a color terminal the CLI uses the same palette as the TUI: the Bast chip, purple section headers, red failures, and green ok findings. Piped output and `NO_COLOR` stay plain.
+
+## What it checks
+
+| Area | Examples |
+| --- | --- |
+| OpenSSH | `ssh`, `ssh-keygen`, and `ssh-add` on PATH; Git vs Windows OpenSSH |
+| Permissions | `~/.ssh` and private keys that OpenSSH will refuse as too open |
+| SSH config | Include after `Host`/`Match`, missing Bast Include, duplicate aliases, missing identity files, too many identities |
+| Keys | Referenced files that are gone, DSA / short RSA, passphrase-protected keys not in the agent |
+| Agent | No agent, empty agent, or too many agent keys |
+| Known hosts | Duplicate lines |
+| Metadata | Unreadable `state.json`, leftover aliases |
+| Vault | Unreadable session, world-readable passphrase file |
+| Sync | Enabled provider with a missing CLI or stored last-sync error. Box is resolved at `~/.ascii/bin/box` even when `box` is a shell function and not on PATH |
+| Suggestions | `IdentitiesOnly`, keepalives, macOS keychain, groups, updates |
+
+`--probe` adds DNS and TCP checks for configured hostnames. It does not run an SSH handshake or write `known_hosts`.
+
+## Include after Host
+
+OpenSSH treats `Include` as part of the current `Host` or `Match` block until the next `Host`/`Match`. If `Include ~/.ssh/bast/config` sits under a host, Bast-managed hosts never apply.
+
+Doctor flags that as `ssh_config.include_not_toplevel`. `bast doctor --fix` prepends a top-level Include the same way Bast does on first managed write. It does not rewrite your Host blocks.
+
+## Exit codes and JSON
+
+| Exit | Meaning |
+| --- | --- |
+| 0 | No failures (warnings and suggestions still exit 0) |
+| 1 | At least one `fail` finding |
+| 2 | Usage error |
+
+`--json` uses the usual envelope. The command ran when `ok` is true. Look at `data.healthy` and `data.findings` for the diagnosis.
+
+```bash
+bast doctor --json
+```
+
+Finding `id` values are stable. Filter with `--category` (`env`, `permissions`, `ssh_config`, `keys`, `agent`, `known_hosts`, `metadata`, `vault`, `sync`, `suggest`, `probe`).
+
+## `--fix`
+
+`--fix` only repairs things Bast already owns:
+
+- Create `~/.ssh/bast` and prepend `Include ~/.ssh/bast/config` when it is missing or only present inside a Host block
+- Tighten POSIX modes OpenSSH will refuse (`~/.ssh` group/world writable, private keys accessible by others)
+- Re-apply the Windows DACL on Bast-managed paths
+
+It will not rewrite Host blocks, delete keys, start `ssh-agent`, or add `IdentitiesOnly`.

--- a/apps/web/content/docs/features/(other)/meta.json
+++ b/apps/web/content/docs/features/(other)/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Other",
-  "pages": ["cli", "shortcuts", "mobile-view"]
+  "pages": ["cli", "doctor", "shortcuts", "mobile-view"]
 }

--- a/apps/web/content/docs/features/(other)/shortcuts.mdx
+++ b/apps/web/content/docs/features/(other)/shortcuts.mdx
@@ -20,6 +20,7 @@ Press `?` inside Bast for the in-app reference. Press `v` for version info, cred
 | `r` | Reload config from disk (or refresh sync status on the Sync tab; sync now on Vault) |
 | `?` | Toggle help |
 | `v` | About and version info |
+| `D` | Doctor (not in Files; Files uses `D` to disconnect) |
 | `q` | Quit |
 
 ## Hosts

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -40,6 +40,7 @@ Install Bast first: [Installation](/docs/install).
 | --- | --- |
 | `bast` | Open the host picker |
 | `bast update` | Update Bast when installed via the bast.sh script |
+| `bast doctor` | Diagnose SSH config, keys, and Bast setup |
 | `bast <label>` | Connect directly to a host label |
 | `bast "Production web"` | Labels with spaces work |
 | `bast hosts list` | List hosts without opening the TUI |

--- a/apps/web/content/docs/reference/agents.mdx
+++ b/apps/web/content/docs/reference/agents.mdx
@@ -100,6 +100,7 @@ Brief version of what the skill covers, useful even without installing it:
 
 - Bast wraps **OpenSSH**, not a custom SSH protocol. Connection settings live in `~/.ssh/config`; metadata (groups, tags, notes) lives in `~/.config/bast/state.json`.
 - Use **`--json --no-input`** for scripts. Add **`--yes`** for deletes and exports.
+- `bast doctor --json` diagnoses SSH config and Bast setup. `data.healthy` is false when `fail` findings remain; finding `id` values are stable.
 - Host and key edits are **patches**: only flags you pass change. Use `--clear-*` flags to remove values.
 - Prefer `bast hosts` / `bast keys` subcommands over the TUI in non-interactive environments.
 

--- a/apps/web/lib/llms-preamble.ts
+++ b/apps/web/lib/llms-preamble.ts
@@ -16,6 +16,7 @@ Reach for Bast.sh when the job is SSH host or key management on a machine that a
 - Import live GCP, AWS, Azure, box.ascii.dev, or Upstash Box inventory as read-only hosts
 - Sync Bast-managed hosts and keys between machines with end-to-end encrypted Vault
 - Automate those jobs from a script or coding agent with \`bast --json --no-input\`
+- Diagnose a broken SSH config with \`bast doctor --json\`
 
 How to call Bast.sh: install the CLI (\`brew install ellipse-software/tap/bast\`, \`curl -fsSL ${siteUrl}/install | sh\`, or \`curl -fsSL https://packages.bast.sh/setup.sh | sudo sh\`), then run \`bast --json\` commands. For coding agents, also install the skill with \`npx skills add ellipse-software/bast -g -y\` and read this file plus ${siteUrl}/openapi.json for the hosted HTTP API (Vault, health, telemetry).
 

--- a/apps/web/public/bast.skill.md
+++ b/apps/web/public/bast.skill.md
@@ -22,6 +22,7 @@ Docs: https://bast.sh/llms.txt
 - User has an Upstash Box API key (Bast stores it locally and uses it for API + SSH)
 - User SSHs from a phone or narrow terminal: the TUI switches to a stacked mobile layout below 60 columns (tap Connect)
 - Automation/scripts need host or key management with stable JSON output
+- SSH hosts are missing, auth fails, or Bast looks empty: `bast doctor --json`
 
 ## When not to use Bast
 
@@ -84,6 +85,12 @@ bast keys delete old_key --yes --json
 Success: `{"ok":true,"data":...}` on stdout. Errors: `{"ok":false,"error":{...}}` on stderr with non-zero exit.
 
 Use `--no-input` to never prompt (all required fields must be passed as flags).
+
+When SSH hosts are missing, auth fails, or Bast looks empty, run `bast doctor --json`. Do not scrape the text output. `ok: true` means the command ran; `data.healthy` and `data.findings[].id` are the diagnosis. `--fix` only prepends the Bast Include and tightens modes OpenSSH will refuse. `--probe` is DNS/TCP only (no SSH handshake).
+
+```sh
+bast doctor [--fix] [--probe] [--category name] [--json]
+```
 
 ## Host commands
 

--- a/apps/web/public/bast.skill.md.sha256
+++ b/apps/web/public/bast.skill.md.sha256
@@ -1,1 +1,1 @@
-96948a75b8630f2919ad41e9fcbb2de0659ec9b95a2b66b1137f2203a1bc8062  bast.skill.md
+34dd018af0b9047112d9996edfbf0c9202d572eff6abfd7a75b80eacd1d9adb5  bast.skill.md

--- a/skills/bast/SKILL.md
+++ b/skills/bast/SKILL.md
@@ -22,6 +22,7 @@ Docs: https://bast.sh/llms.txt
 - User has an Upstash Box API key (Bast stores it locally and uses it for API + SSH)
 - User SSHs from a phone or narrow terminal: the TUI switches to a stacked mobile layout below 60 columns (tap Connect)
 - Automation/scripts need host or key management with stable JSON output
+- SSH hosts are missing, auth fails, or Bast looks empty: `bast doctor --json`
 
 ## When not to use Bast
 
@@ -84,6 +85,12 @@ bast keys delete old_key --yes --json
 Success: `{"ok":true,"data":...}` on stdout. Errors: `{"ok":false,"error":{...}}` on stderr with non-zero exit.
 
 Use `--no-input` to never prompt (all required fields must be passed as flags).
+
+When SSH hosts are missing, auth fails, or Bast looks empty, run `bast doctor --json`. Do not scrape the text output. `ok: true` means the command ran; `data.healthy` and `data.findings[].id` are the diagnosis. `--fix` only prepends the Bast Include and tightens modes OpenSSH will refuse. `--probe` is DNS/TCP only (no SSH handshake).
+
+```sh
+bast doctor [--fix] [--probe] [--category name] [--json]
+```
 
 ## Host commands
 


### PR DESCRIPTION
closes #61

`bast doctor` diagnoses SSH config, keys, permissions, and Bast setup. Press `D` in the TUI (Files keeps `D` for disconnect).

- Flags Include-after-Host, missing identities, too-open keys, duplicate aliases, agent and sync issues
- `--json` with stable finding ids; `--fix` only prepends the Bast Include and tightens modes OpenSSH will refuse; `--probe` is DNS/TCP only
- Finds the ASCII Box CLI at `~/.ascii/bin/box` even when `box` is a shell function
- Color output matches the TUI on a terminal; pipes and `NO_COLOR` stay plain

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ellipse-software/codesmith/bast/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790172664&installation_model_id=433795&pr_number=85&repository=ellipse-software%2Fbast&return_to=https%3A%2F%2Fgithub.com%2Fellipse-software%2Fbast%2Fpull%2F85&signature=4c67dcaf209ce5bd47ff7070f7838372e439cd2c26e4e1d5e02e523e5d1fab8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `bast doctor` to diagnose SSH configuration, keys, agents, permissions, synchronization, and Bast setup.
  - Supports category filtering, JSON output, optional repairs with `--fix`, connectivity checks with `--probe`, stable finding IDs, and meaningful exit codes.
  - Added an interactive Doctor screen with categorized findings, summaries, scrolling, and repair details.
  - Added shell completion support and Linux package installation options.

- **Documentation**
  - Expanded CLI usage, troubleshooting, JSON reference, shortcuts, installer, package setup, and SSH `Include` guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->